### PR TITLE
Bb history display

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2019-01-31  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-history-in-new-buffer): New option.
+	(w3m-db-history): Apply the new option. Add details to docstring. Allow
+	interactive user to set function options START and SIZE.
+	(w3m-history): Apply the new option. Improve docstring.
+	(w3m-about-history): Add programmer's note. Modify Docstring.
+	(w3m-about-db-history): Add programmer's note. Modify Docstring. Properly
+	handle START and SIZE arguments. Modify html output for: clarity, date
+	display format, use of ellipsis, maximum use of page width, center
+	heading, align page navigation links to page edges, remove extraneous
+	';' after url's, add ellipsis when truncating url's.
+
 2019-01-31  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m-bug.el (report-emacs-w3m-bug-system-informations):

--- a/w3m.el
+++ b/w3m.el
@@ -10991,8 +10991,10 @@ default. Use 0 to display the entire history on a single page."
     (when (not start) (setq start 0))
     (when (not size)  (setq size w3m-db-history-display-size)))
    (t ; called interactively; possibly indirectly
-    (setq start (read-number "start: " (or w3m-db-history-display-size 0)))
-    (setq size (read-number "size: " (or size 0)))))
+    (setq start (read-number "How far back in the history to start displaying?: "
+                  (or w3m-db-history-display-size 0)))
+    (setq size (read-number "How many entries per page (0 for all on one page)?: "
+                  (or size 0)))))
   (let ((url (format "about://db-history/?start=%d&size=%d"
                (or start 0) (or size 0))))
    (if w3m-history-in-new-buffer

--- a/w3m.el
+++ b/w3m.el
@@ -10733,7 +10733,11 @@ a number.")
 A history page is invoked by the `w3m-about-history' command.")
 
 (defun w3m-about-history (&rest args)
-  "Show a tree-structured history."
+  "Render the current buffer's tree-structured browsing history in HTML."
+  ;; ARGS is not used. It is necessary in order to >/dev/null
+  ;; unnecessary arguments because this function is one of several
+  ;; called by `w3m-about-retrieve' using a generically constructed
+  ;; `funcall'.
   (let (start history current)
     (with-current-buffer w3m-current-buffer
       (setq history w3m-history-flat
@@ -10817,16 +10821,24 @@ A history page is invoked by the `w3m-about-history' command.")
     "text/html"))
 
 (defun w3m-about-db-history (url &rest args)
+  "Render a flat chronological HTML list of all buffers' browsing history."
+  ;; ARGS is not used. It is necessary in order to >/dev/null
+  ;; unnecessary arguments because this function is one of several
+  ;; called by `w3m-about-retrieve' using a generically constructed
+  ;; `funcall'.
   (let ((start 0)
-	(size nil)
-	(width (- (w3m-display-width) 18))
+        (size 0)
+        (print-all t)
+        (width (- (w3m-display-width) 19))
 	(now (current-time))
 	title time alist prev next page total)
     (when (string-match "\\`about://db-history/\\?" url)
       (dolist (s (split-string (substring url (match-end 0)) "&"))
-	(when (string-match "\\`\\(?:start\\|\\(size\\)\\)=" s)
-	  (set (if (match-beginning 1) 'size 'start)
-	       (string-to-number (substring s (match-end 0)))))))
+        (when (string-match "\\`\\(?:size\\|\\(start\\)\\)=" s)
+          (if (match-beginning 1)
+            (setq start (string-to-number (substring s (match-end 0))))
+           (setq size (string-to-number (substring s (match-end 0))))
+           (when (/= size 0) (setq print-all nil))))))
     (when w3m-arrived-db
       (mapatoms
        (lambda (sym)
@@ -10841,7 +10853,7 @@ A history page is invoked by the `w3m-about-history' command.")
 			  (w3m-time-newer-p (cdr a) (cdr b))))))
     (setq total (length alist))
     (setq alist (nthcdr start alist))
-    (when size
+    (when (/= size 0)
       (when (> start 0)
 	(setq prev
 	      (format "about://db-history/?start=%d&size=%d"
@@ -10857,47 +10869,54 @@ A history page is invoked by the `w3m-about-history' command.")
 	    (if prev (format "<link rel=\"prev\" href=\"%s\">\n" prev) "")
 	    (if next (format "<link rel=\"next\" href=\"%s\">\n" next) "")
 	    (format
-	     "</head>\n<body>\n<h1>Arrived URL history in DataBase%s</h1>\n"
+             "</head><body><center><h1>Global URL history for all w3m buffers%s</h1></center>\n"
 	     (if (and page total)
-		 (format " (%d/%d)" page total) "")))
+                 (format " (page %d/%d)" page total) "")))
     (setq prev
 	  (if (or prev next)
 	      (setq next
 		    (concat
-		     "<p align=\"left\">"
+                     "<table width=100%><tr>"
 		     (if prev
-			 (format "[<a href=\"%s\">Prev History</a>]" prev)
-		       "")
+                         (format "<td width=50%% align=\"left\">[<a href=\"%s\">Prev Page</a>]</td>" prev)
+                       "<td width=50%%></td>")
 		     (if next
-			 (format "[<a href=\"%s\">Next History</a>]" next)
-		       "")
-		     "</p>\n"))
+                         (format "<td width=50%% align=\"right\">[<a href=\"%s\">Next Page</a>]</td>" next)
+                       "<td width=50%%></td>")
+                     "</tr></table>\n"))
 	    ""))
     (if (null alist)
 	(insert "<em>Nothing in DataBase.</em>\n")
-      (insert prev "<table cellpadding=0>
+      (insert prev "<table width=100% cellpadding=0>
 <tr><td><h2> Title/URL </h2></td><td><h2>Time/Date</h2></td></tr>\n")
-      (while (and alist
-		  (or (not size)
-		      (>= (decf size) 0)))
+      (while (and alist (or (>= (decf size) 0) print-all))
 	(setq url (car (car alist))
 	      time (cdr (car alist))
 	      alist (cdr alist)
 	      title (w3m-arrived-title url))
-	(if (or (null title)
-		(string= "<no-title>" title))
-	    (setq title (concat "<" (w3m-truncate-string url width) ">"))
-	  (when (>= (string-width title) width)
-	    (setq title (concat (w3m-truncate-string title width) "..."))))
-	(insert (format "<tr><td><a href=\"%s\">%s</a></td>"
-			url
-			(w3m-encode-specials-string title)))
+        (cond
+         ((or (null title) (string= "<no-title>" title))
+          (setq title
+            (concat
+              "&lt;"
+              (if (>= (string-width url) width)
+                (concat (w3m-truncate-string url (1- width)) "…")
+               url)
+              "&gt")))
+         (t
+          (setq title
+            (w3m-encode-specials-string
+              (if (>= (string-width title) width)
+                (concat (w3m-truncate-string title (1+ width)) "…")
+               title)))))
+       (insert (format "<tr><td><a href=\"%s\">%s</a></td>"
+                        url title))
 	(when time
 	  (insert "<td>"
 		  (if (<= (w3m-time-lapse-seconds time now)
 			  64800) ;; = (* 60 60 18) 18hours.
-		      (format-time-string "%H:%M:%S" time)
-		    (format-time-string "%Y-%m-%d" time))
+                      (format-time-string "%H:%M:%S Today" time)
+                    (format-time-string "%H:%M:%S %Y-%m-%d" time))
 		  "</td>"))
 	(insert "</tr>\n"))
       (insert "</table>"
@@ -10947,22 +10966,60 @@ It does manage history position data as well."
   :type '(radio (const :tag "All entries are displayed in single page." nil)
 		(integer :format "%t: %v\n")))
 
+(defcustom w3m-history-in-new-buffer nil
+  "Whether to display URL histories in the current buffer."
+  :group 'w3m
+  :type 'boolean)
+
 (defun w3m-db-history (&optional start size)
-  "Display arrived URLs."
-  (interactive
-   (list nil w3m-db-history-display-size))
-  (w3m-goto-url (concat
-		 (format "about://db-history/?start=%d" (or start 0))
-		 (if size (format "&size=%d" size) ""))
-		 nil nil nil nil nil nil nil t))
+  "Display a flat chronological list of all buffers' browsing history.
+
+This is a flat (not hierarchial) presentation of all URLs visited
+by ALL w3m buffers, and includes a timestamp for when the URL was
+visited. The list is presented in reverse-chronological order,
+ie. most recent URL first.
+
+START is a positive integer for the point in the history list at
+which to begin displaying, where 0 is the most recent entry.
+
+SIZE is the maximum number of arrived URLs which are displayed
+per page. Variable `w3m-db-history-display-size' sets the
+default. Use 0 to display the entire history on a single page."
+  (interactive)
+  (cond
+   ((or executing-kbd-macro noninteractive)
+    (when (not start) (setq start 0))
+    (when (not size)  (setq size w3m-db-history-display-size)))
+   (t ; called interactively; possibly indirectly
+    (setq start (read-number "start: " (or w3m-db-history-display-size 0)))
+    (setq size (read-number "size: " (or size 0)))))
+  (let ((url (format "about://db-history/?start=%d&size=%d"
+               (or start 0) (or size 0))))
+   (if w3m-history-in-new-buffer
+     (w3m-goto-url-new-session url)
+    (w3m-goto-url url :save-pos t))))
 
 (defun w3m-history (&optional arg)
-  "Display the history of all the links you have visited in the session.
-If it is called with the prefix argument, display the arrived URLs."
-  (interactive "P")
-  (if (null arg)
-      (w3m-goto-url "about://history/" nil nil nil nil nil nil nil t)
-    (w3m-db-history nil w3m-db-history-display-size)))
+  "Display the current buffer's browsing history tree.
+
+If called with the prefix argument, display a flat chronological
+list of ALL buffers' browsing history.
+
+A buffer's history tree is a hierarchal presentation of all
+URLs visited by the current buffer and its \"parents\", meaning
+that if the buffer was spawned using a command such as
+`w3m-goto-url-new-session', its history will include that of the
+prior w3m buffer.
+
+The flat chronological list is not hierarchial, but includes all
+URLs visited by ALL w3m buffers, as well as a timestamp for when
+the URL was visited. "
+ (interactive "P")
+  (if arg
+    (w3m-db-history nil w3m-db-history-display-size)
+   (if w3m-history-in-new-buffer
+     (w3m-goto-url-new-session "about://history/")
+    (w3m-goto-url "about://history/" :save-pos t))))
 
 (defun w3m-w32-browser-with-fiber (url)
   (let ((proc (start-process "w3m-w32-browser-with-fiber"


### PR DESCRIPTION
This PR was originally shared on the mailing list ~[13091]. It fixes the handling of the START and SIZE args for the global history display, applies cosmetic changes to that display, and adds an option for all forms of history display to be done in a new buffer.