### PR TITLE
bugfix: w3m-dtree shouldn't abort on subdir permission restriction

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,14 @@
+2019-02-12  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-dtree.el (w3m-dtree-create-sub): BUGFIX: don't abort if a subdir
+	denies permission to read.
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* Refactor entire codebase for utf-8. There were a zillion changes in
 	this commit, spread over very many files. See the git commit extended
 	message for details.
-  
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-cookie.el (w3m-cookie-shutdown): avoid duplicate get-buffer call.

--- a/w3m-dtree.el
+++ b/w3m-dtree.el
@@ -127,7 +127,9 @@ over the 'w3m-dtree-directory-depth'."
 	  (/= (nth 1 (file-attributes ,path)) 2))))
 
 (defun w3m-dtree-create-sub (path allfiles dirprefix fileprefix indent depth)
-  (let* ((files (directory-files path t))
+  (let* ((files (condition-case err
+                  (directory-files path t)
+                  (error (list "----"))))
 	 (limit (and (integerp w3m-dtree-directory-depth)
 		     (>= depth w3m-dtree-directory-depth)))
 	 (indent-sub1 (if limit


### PR DESCRIPTION
To reproduce this bug, perform w3m-dtree on a folder that has many sub-folders, one of which has been chmod'ed 0.