### PR TITLE
New feature: copy links to OS clipboard

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,24 @@
+2019-02-12  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-util.el (w3m--send-to-gui-clipboard): New function.
+	(w3m-gui-clipboard-commands): New defcustom. WARNING: This has a known
+	bug that the radio buttons are not initializing properly - they always
+	set to the first button in the list.
+
+	* w3m.el (w3m-print-current-url, w3m-print-this-url,
+	w3m-print-this-image-url): Use the new feature.
+
+	* w3m-lnum.el (w3m-lnum-print-this-url): Use the new feature
+	(w3m-lnum-bookmark-add-this-url, w3m-lnum-download-this-url,
+	w3m-lnum-print-this-url, w3m-lnum-edit-this-url,
+	w3m-lnum-external-view-this-url): Alter docstring.
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* Refactor entire codebase for utf-8. There were a zillion changes in
 	this commit, spread over very many files. See the git commit extended
 	message for details.
-  
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-cookie.el (w3m-cookie-shutdown): avoid duplicate get-buffer call.

--- a/w3m-lnum.el
+++ b/w3m-lnum.el
@@ -1074,7 +1074,9 @@ interactively resize."
 ;;;###autoload
 (defun w3m-lnum-external-view-this-url ()
   "Launch the external browser and display the link at point.
-If no link at point, turn on link numbers and open selected externally."
+
+If there is no link at point, this function activates numbering
+of visible links, and prompts the user to select one to open externally."
   (interactive)
   (let ((url (w3m-url-valid (or (w3m-anchor) (w3m-image)
 				(car
@@ -1087,7 +1089,9 @@ If no link at point, turn on link numbers and open selected externally."
 ;;;###autoload
 (defun w3m-lnum-edit-this-url ()
   "Edit the page linked from the anchor under the cursor.
-If no such, turn on link numbers and edit selected."
+
+If there is no link at point, this function activates numbering
+of visible links, and promopts the user to select one to edit."
   (interactive)
   (let ((url (or (w3m-url-valid (w3m-anchor))
 		 (car (w3m-lnum-get-action
@@ -1097,8 +1101,11 @@ If no such, turn on link numbers and edit selected."
 
 ;;;###autoload
 (defun w3m-lnum-print-this-url ()
-  "Display the url under point in the echo area and put it into `kill-ring'.
-If no url under point, activate numbering and select one."
+  "Display the url under point in the echo area.
+
+Also, put it into the `kill-ring' and the OS clipboard.
+If there is no url under point, this function activates numbering
+of visible URLs and prompts the user to select one."
   (interactive)
   (if (or (w3m-anchor) (w3m-image))
       (w3m-print-this-url t)
@@ -1106,6 +1113,7 @@ If no url under point, activate numbering and select one."
       (if link
 	  (let ((url (car link)))
 	    (kill-new url)
+            (w3m--send-to-gui-clipboard url)
 	    (w3m-message "%s%s" (let ((im-alt (nth 3 link)))
 				  (if (zerop (length im-alt)) ""
 				    (concat im-alt ": ")))
@@ -1115,7 +1123,9 @@ If no url under point, activate numbering and select one."
 ;;;###autoload
 (defun w3m-lnum-download-this-url ()
   "Download the file or the page pointed to by the link under point.
-If no point, activate numbering and select andchor to download."
+
+If there is no link under point,  this function activates numbering
+of visible links and prompts the user to select one to download."
   (interactive)
   (if (or (w3m-anchor) (w3m-image) (w3m-action))
       (w3m-download-this-url)
@@ -1130,7 +1140,9 @@ If no point, activate numbering and select andchor to download."
 ;;;###autoload
 (defun w3m-lnum-bookmark-add-this-url ()
   "Add link under cursor to bookmarks.
-If no link under point, activate numbering and ask for one."
+
+If there is no link under point, this function activates numbering
+of visible URLs and prompts the user to select one."
   (interactive)
   (let ((url (w3m-anchor)))
     (cond

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1833,6 +1833,33 @@ rather than relying on `lexical-binding'.
 	  (buffer-substring-no-properties (point-min) (point-max))))
     url))
 
+(defcustom w3m-gui-clipboard-commands
+  '((gnu/linux . "printf '%s' | xsel -i -b"))
+  "How to send text to your system clipboard.
+
+When entering the command string, use \"%s\" to denote the actual
+data to be copied."
+  :group 'w3m
+  :type '(repeat
+           (cons :indent 4
+              (radio :indent 8
+	        (symbol :format "GNU/Linux\n"         gnu/linux)
+                (symbol :format "GNU Hurd\n"          gnu)
+	        (symbol :format "GNU/FreeBSD\n"       gnu/kfreebsd )
+	        (symbol :format "Darwin (MacOS)\n"    darwin)
+	        (symbol :format "MS-DOS\n"            ms-dos)
+	        (symbol :format "Windows NT 32-bit\n" windows-nt)
+	        (symbol :format "Cygwin\n"            cygwin))
+              (string :indent 8 :format "Command string: %v" ))))
+
+(defun w3m--send-to-gui-clipboard (content)
+  (let ((cmd (cdr (assq system-type w3m-gui-clipboard-commands))))
+    (if (not cmd)
+      (w3m--message t 'w3m-warning "No command to copy to gui clipboard.")
+     (if (not (string-match "%s" cmd))
+       (w3m--message t 'w3m-error "Malformed variable w3m-gui-clipboard-commands.")
+      (shell-command (replace-match (substring-no-properties content) t t cmd))))))
+
 (provide 'w3m-util)
 
 ;;; w3m-util.el ends here

--- a/w3m.el
+++ b/w3m.el
@@ -7614,17 +7614,23 @@ of the url currently displayed.  The browser is defined in
       (w3m-message "No image at point")))))
 
 (defun w3m-print-current-url ()
-  "Display the current url in the echo area and put it into `kill-ring'."
+  "Display the current url in the echo area.
+
+Also, put it into the `kill-ring' and the OS clipboard."
   (interactive)
   (when w3m-current-url
-    (let ((deactivate-mark nil))
-      (kill-new (w3m-url-encode-string-2 w3m-current-url))
+    (let ((deactivate-mark nil)
+          (url (w3m-url-encode-string-2 w3m-current-url)))
+      (kill-new url)
+      (w3m--send-to-gui-clipboard url)
       (w3m-message "%s" (w3m-url-readable-string w3m-current-url)))))
 
 (defvar message-truncate-lines)
 
 (defun w3m-print-this-url (&optional interactive-p)
-  "Display the url under point in the echo area and put it into `kill-ring'."
+  "Display the url under point in the echo area.
+
+Also, put it into the `kill-ring' and the OS clipboard."
   (interactive (list t))
   (let ((deactivate-mark nil)
 	(url (if interactive-p
@@ -7646,7 +7652,9 @@ of the url currently displayed.  The browser is defined in
 		   (w3m-anchor-title)
 		 (w3m-anchor-title (point)))))
     (when (or url interactive-p)
-      (and url interactive-p (kill-new (w3m-url-encode-string-2 url)))
+      (when (and url interactive-p)
+        (kill-new (w3m-url-encode-string-2 url))
+        (w3m--send-to-gui-clipboard url))
       (setq url (or (w3m-url-readable-string url)
 		    (and (w3m-action) "There is a form")
 		    "There is no url under point"))
@@ -7669,7 +7677,9 @@ of the url currently displayed.  The browser is defined in
 			  url))))))
 
 (defun w3m-print-this-image-url (&optional interactive-p)
-  "Display image url under point in echo area and put it into `kill-ring'."
+  "Display image url under point in echo area.
+
+Also, put it into the `kill-ring' and the OS clipboard."
   (interactive (list t))
   (let ((deactivate-mark nil)
 	(url (if interactive-p
@@ -7679,7 +7689,9 @@ of the url currently displayed.  The browser is defined in
 		 (w3m-image-alt)
 	       (w3m-image-alt (point)))))
     (when (or url interactive-p)
-      (and url interactive-p (kill-new (w3m-url-encode-string-2 url)))
+      (when (and url interactive-p)
+        (kill-new (w3m-url-encode-string-2 url))
+        (w3m--send-to-gui-clipboard url))
       (w3m-message "%s%s"
 		   (if (zerop (length alt))
 		       ""


### PR DESCRIPTION
+ IMPORTANT: See below for 'issues'...

+ New function w3m--send-to-gui-clipboard

+ New defcustom w3m-gui-clipboard-commands

+ Feature applied to existing functions that copy link
  information to the emacs kill-ring.
  + w3m-print-current-url
  + w3m-print-this-url
  + w3m-print-this-image-url
  + w3m-lnum-print-this-url

+ New docstrings for some functions

+ ISSUES

  + BUG! I'm still having trouble getting defcustom to do
    what I want. In this case, customize-variable
    improperly displays the car of each cons cell as the
    first radio button on the list.

  + MISSING INFORMATION! I'm only familiar with linux, so I
    wasn't able to populate w3m-gui-clipboard-commands for
    other operating systems. Even if someone gives me a set
    of command strings, I have no way of testing them.

  + Tsuchiya-san recently expressed interest in a 'private
    browsing' mode for emacs-w3m.

    + This feature does make browsing a little less private
      in that anything copied to the emacs kill-ring is
      shared with the OS clipboard.

    + I can easily set a configuration value for the
      feature, but it might be more forward-thinking to
      label that value generically as something like
      w3m-private-mode instead of something specific like
      w3m-kill-ring-copies-to-os-clipboard.

    + It might just be best to wait until there exists a
      more detailed specification or expectation of what
      some private-mode would offer. For example, it may be
      decided to allow the copies, and upon exit to clear
      both the emacs kill-ring and the OS clipboard.