### PR TITLE
bb_messaging: add consistency, timeouts, and faces to messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2019-02-14  Boruch Baum  <boruch_baum@gmx.com>
 
+	* w3m.el (w3m-resize-image-interactive): refactor function to remove
+	duplications in code.
+
+2019-02-14  Boruch Baum  <boruch_baum@gmx.com>
+
 	* mime-w3m.el (mime-w3m-preview-text/html): Convert
 	message to w3m--message.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,54 @@
+2019-02-14  Boruch Baum  <boruch_baum@gmx.com>
+
+	* mime-w3m.el (mime-w3m-preview-text/html): Convert
+	message to w3m--message.
+
+	* mew-w3m.el (mew-w3m-ext-url-fetch, w3m-mail-compose-with-mew):
+	Convert message to w3m--message.
+
+	* w3m.el (w3m-arrived-shutdown, w3m-load-list)
+	(w3m-toggle-inline-images-internal, )
+	(w3m-resize-inline-image-internal, w3m-download)
+	(w3m-search-name-anchor, w3m-view-previous-page)
+	(w3m-view-url-with-external-browser, w3m-move-unseen-buffer)
+	(w3m-goto-ftp-url, w3m-goto-new-session-url)
+	(w3m-resize-image-interactive): Convert message to w3m--message.
+
+	* w3m-bookmark.el (w3m-bookmark-add-this-url)
+	(w3m-bookmark-add-current-url, w3m-bookmark-add-current-url-group)
+	(w3m-bookmark-view, w3m-bookmark-add-all-urls): Convert message to
+	w3m--message.
+
+	* w3m-cookie.el (w3m-cookie-1-set, w3m-cookie-shutdown): Convert
+	message to w3m--message.
+
+	* w3m-fb.el (w3m-fb-mode): Convert message to w3m--message.
+
+	* w3m-filter.el (w3m-toggle-filtering): Convert message to
+	w3m--message.
+
+	* w3m-form.el (w3m-form-input-password, w3m-form-input-textarea-set)
+	(w3m-form-input-textarea-exit, w3m-form-textarea-toggle-major-mode):
+	Convert message to w3m--message.
+
+	* w3m-hist.el (w3m-history-add-properties)
+	(w3m-history-store-position, w3m-history-restore-position): Convert
+	message to w3m--message.
+
+	* w3m-image.el (w3m-imagick-convert-program-available-p)
+	(w3m-imagick-convert-buffer): Convert message to w3m--message.
+
+	* w3m-session.el (w3m-session-save)
+	(w3m-session-select-list-all-sessions)
+	(w3m-session-select-open-session-group, w3m-session-select)
+	(w3m-session-goto-session): Convert message to w3m--message.
+
+	* w3m-util.el (read-number): Convert message to w3m--message.
+
+	* w3m-xmas.el (w3m-create-image)
+	(w3m-form-coding-system-accept-region-p): Convert message to
+	w3m--message.
+
 2019-02-12  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (w3m--message): Renamed function w3m-message, added two

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,67 @@
+2019-02-12  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m--message): Renamed function w3m-message, added two
+	mandatory arguments TIMEOUT and FACE, added those features, refactored
+	entire codebase to use the new function and features.
+	(w3m-message-timeout): New defcustom, for a users' preferred timeout.
+	(w3m--message-timeout): New variable, for system default timeout.
+	(w3m--current-message): Renamed variable, using '--' to connote
+	that its for internal use.
+	(w3m-message): New face, for default messages.
+	(w3m-warning): New face, for warning messages.
+	(w3m-idle-images-show, w3m-toggle-inline-image)
+	(w3m-toggle-inline-images, w3m-resize-image-interactive)
+	(w3m-zoom-out-image, w3m-fontify, w3m-local-dirlist-cgi)
+	(w3m-w3m-dump-head, w3m--dump-extra--handler-function)
+	(w3m-w3m-dump-extra, w3m--retrieve--handler-function)
+	(w3m-w3m-retrieve, w3m-rendering-buffer)
+	(w3m--retrieve-and-render--handler-function, w3m-retrieve-and-render)
+	(w3m-view-this-url, w3m-submit-form, w3m-external-view-file)
+	(w3m-view-image, w3m-save-image, w3m-external-view-this-url)
+	(w3m-external-view-current-url, w3m-view-url-with-browse-url)
+	(w3m-download-this-url, w3m-download-this-image)
+	(w3m-download-this-url, w3m-download-this-image)
+	(w3m-print-this-image-url, w3m-highlight-current-anchor-1)
+	(w3m-edit-this-url, w3m-goto-url, w3m-reload-this-page)
+	(w3m-redisplay-this-page, w3m-redisplay-and-reset)
+	(w3m-redisplay-with-charset, w3m-redisplay-with-content-type)
+	(w3m-view-source, w3m-view-header, w3m-pipe-source)
+	(w3m-select-buffer, w3m-select-buffer-show-this-line)
+	(w3m-safe-view-this-url, w3m-mouse-safe-view-this-url)
+	(w3m-show-form-hint): Use the new function and its features.
+
+	* w3m-cookie.el (w3m-cookie-clear): Use the new function and its
+	features.
+
+	* w3m-dtree.el (w3m-about-dtree): Use the new function and its
+	features.
+
+	* w3m-favicon.el (autoload, w3m-favicon-retrieve): Use the new function
+	and its features.
+
+	* w3m-form.el (w3m-form-input, w3m-form-input-checkbox)
+	(w3m-form-input-radio, w3m-form-input-file)
+	(w3m-form-input-textarea-mode-setup, w3m-form-input-select)
+	(w3m-form-submit): Use the new function and its features.
+
+	* w3m-lnum.el (w3m-lnum-actions-link-alist, w3m-lnum-mode)
+	(w3m-lnum-goto, w3m-lnum-follow, w3m-lnum-universal-dispatch)
+	(w3m-lnum-universal, w3m-lnum-toggle-inline-image)
+	(w3m-lnum-view-image, w3m-lnum-save-image)
+	(w3m-lnum-external-view-this-url, w3m-lnum-edit-this-url)
+	(w3m-lnum-print-this-url, w3m-lnum-download-this-url)
+	(w3m-lnum-bookmark-add-this-url): Use the new function and its
+	features.
+
+	* w3m-weather.el (w3m-about-weather): Use the new function and its
+	features.
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* Refactor entire codebase for utf-8. There were a zillion changes in
 	this commit, spread over very many files. See the git commit extended
 	message for details.
-  
+
 2019-02-03  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-cookie.el (w3m-cookie-shutdown): avoid duplicate get-buffer call.

--- a/mew-w3m.el
+++ b/mew-w3m.el
@@ -376,10 +376,10 @@ The variable `mew-w3m-region-cite-mark' specifies the citation mark."
     (w3m-process-do
 	(success (prog1
 		     (w3m-download url nil nil handler)
-		   (message "Download: %s..." name)))
+		   (w3m--message nil t "Downloading: %s..." name)))
       (if success
-	  (message "Download: %s...done" name)
-	(message "Download: %s...failed" name))
+	  (w3m--message t t "Download: %s...done" name)
+	(w3m--message t 'w3m-error "Download: %s...failed" name))
       (sit-for 1))))
 
 (defun w3m-mail-compose-with-mew (source url charset content-type
@@ -419,7 +419,7 @@ The variable `mew-w3m-region-cite-mark' specifies the citation mark."
     (when (eq csorig mew-cs-unknown)
       (setq csorig nil))
     (if (or (not last) (not (mew-attach-not-line012-1)))
-	(message "Can not attach from emacs-w3m here!")
+	(w3m--message t 'w3m-error "Can not attach from emacs-w3m here!")
       ;; Application/.*xml is not inline view with Mew.
       (cond
        ((string= "application/xhtml+xml" ct)
@@ -510,7 +510,7 @@ The variable `mew-w3m-region-cite-mark' specifies the citation mark."
 	  (mew-syntax-set-ct syntax ctl))
 	(mew-syntax-set-cd syntax url)
 	(mew-encode-syntax-print mew-encode-syntax))
-      (message "Compose a mail using Mew with %s...done" url)
+      (w3m--message t t "Compose a mail using Mew with %s...done" url)
       (when (and (file-exists-p filename) (file-writable-p filename))
 	(delete-file filename)))))
 

--- a/mime-w3m.el
+++ b/mime-w3m.el
@@ -176,7 +176,7 @@ by way of `post-command-hook'."
 	     (add-text-properties p (point-max)
 				  (list 'keymap w3m-minor-mode-map
 					'text-rendered-by-mime-w3m t)))
-	 (error (message "%s" err)))))))
+	 (error (w3m--message t 'w3m-error "%s" err)))))))
 
 (let (current-load-list)
   (defadvice mime-display-message

--- a/w3m-bookmark.el
+++ b/w3m-bookmark.el
@@ -308,14 +308,14 @@ Optional argument TITLE is title of link."
   "Add link under cursor to bookmark."
   (interactive)
   (if (null (w3m-anchor))
-      (message "No anchor")		; nothing to do
+      (w3m--message t 'w3m-error "No anchor")		; nothing to do
     (let ((url (w3m-anchor))
 	  (title (buffer-substring-no-properties
 		  (previous-single-property-change (1+ (point))
 						   'w3m-href-anchor)
 		  (next-single-property-change (point) 'w3m-href-anchor))))
       (w3m-bookmark-add url title))
-    (message "Added")))
+    (w3m--message t t "Added")))
 
 ;;;###autoload
 (defun w3m-bookmark-add-current-url (&optional arg)
@@ -324,7 +324,7 @@ With prefix, ask for a new url instead of the present one."
   (interactive "P")
   (w3m-bookmark-add (if arg (w3m-input-url) w3m-current-url)
 		    w3m-current-title)
-  (message "Added"))
+  (w3m--message t t "Added"))
 
 ;;;###autoload
 (defun w3m-bookmark-add-all-urls ()
@@ -338,7 +338,7 @@ With prefix, ask for a new url instead of the present one."
 	  (condition-case nil
 	      (w3m-bookmark-add-current-url)
 	    (quit)))
-      (message
+      (w3m--message t 'w3m-warning
        "Use the `%s' command instead"
        (key-description (car (where-is-internal 'w3m-bookmark-add-current-url
 						w3m-mode-map)))))))
@@ -355,7 +355,7 @@ With prefix, ask for a new url instead of the present one."
 		      (with-current-buffer buffer w3m-current-url))
 		    (w3m-list-buffers))
 	    "&")))
-  (message "Added as URL group"))
+  (w3m--message t t "Added as URL group"))
 
 ;;;###autoload
 (defun w3m-bookmark-view (&optional reload)
@@ -366,17 +366,17 @@ With prefix, ask for a new url instead of the present one."
 	;; Store the current position in the history structure.
 	(w3m-history-store-position)
 	(w3m-goto-url "about://bookmark/" reload))
-    (message "No bookmark file is available")))
+    (w3m--message t 'w3m-error "No bookmark file is available")))
 
 ;;;###autoload
 (defun w3m-bookmark-view-new-session (&optional reload)
   "Display the bookmark list in a new buffer."
   (interactive "P")
   (if (not (eq major-mode 'w3m-mode))
-      (message "This command can be used in w3m mode only")
+      (w3m--message t 'w3m-error "This command can be used in w3m mode only")
     (if (file-exists-p w3m-bookmark-file)
 	(w3m-view-this-url-1 "about://bookmark/" reload 'new-session)
-      (message "No bookmark file is available"))))
+      (w3m--message t 'w3m-error "No bookmark file is available"))))
 
 ;;;###autoload
 (defun w3m-about-bookmark (&rest args)

--- a/w3m-cookie.el
+++ b/w3m-cookie.el
@@ -435,7 +435,7 @@ If ask, ask user whether accept bad cookies or not."
   (dolist (buffer (w3m-list-buffers t))
     (with-current-buffer buffer
       (when (equal w3m-current-url "about://cookie/")
-	(let ((w3m-message-silent t))
+	(let ((w3m--message-silent t))
 	  (w3m-reload-this-page nil t))))))
 
 (defun w3m-cookie-save (&optional domain)

--- a/w3m-cookie.el
+++ b/w3m-cookie.el
@@ -392,7 +392,7 @@ If ask, ask user whether accept bad cookies or not."
 			    :expires expires
 			    :secure secure)))
        (t
-	(message "%s tried to set a cookie for domain %s - rejected."
+	(w3m--message t 'w3m-error "%s tried to set a cookie for domain %s - rejected."
 		 (w3m-http-url-host http-url) domain))))))
 
 ;;; Version 1 cookie.
@@ -492,7 +492,7 @@ When DOMAIN is non-nil, only save cookies whose domains match it."
     (error
      (if interactive-p
 	 (signal (car err) (cdr err))
-       (message "Error while running w3m-cookie-shutdown: %s"
+       (w3m--message t 'w3m-error "Error while running w3m-cookie-shutdown: %s"
 		(error-message-string err))))))
 
 (add-hook 'kill-emacs-hook 'w3m-cookie-shutdown)

--- a/w3m-dtree.el
+++ b/w3m-dtree.el
@@ -208,9 +208,9 @@ over the 'w3m-dtree-directory-depth'."
     ;; counter drive letter
     (setq path (file-name-as-directory (w3m-dtree-directory-name path)))
     (setq default-directory path)
-    (w3m-message "Dtree (%s)..." path)
+    (w3m--message nil nil "Dtree (%s)..." path)
     (w3m-dtree-create path allfiles dirprefix fileprefix)
-    (w3m-message "Dtree...done")
+    (w3m--message t nil "Dtree...done")
     "text/html"))
 
 ;;;###autoload

--- a/w3m-favicon.el
+++ b/w3m-favicon.el
@@ -48,7 +48,7 @@
   (defvar w3m-work-buffer-list)
   (autoload 'w3m-expand-url "w3m")
   (autoload 'w3m-load-list "w3m")
-  (autoload 'w3m-message "w3m")
+  (autoload 'w3m--message "w3m")
   (autoload 'w3m-retrieve "w3m")
   (autoload 'w3m-save-list "w3m")
   (autoload 'w3m-url-readable-string "w3m"))
@@ -311,11 +311,11 @@ stored in the `w3m-favicon-image' buffer-local variable."
     (lexical-let ((url url)
 		  (type type)
 		  (target target)
-		  (silent w3m-message-silent))
+		  (silent w3m--message-silent))
       (w3m-process-with-null-handler
 	(w3m-process-do-with-temp-buffer
 	    (ok (w3m-retrieve url 'raw nil nil nil handler))
-	  (let ((w3m-message-silent silent)
+	  (let ((w3m--message-silent silent)
 		idata image)
 	    (if (and ok
 		     ;; Some broken servers provides empty contents.
@@ -330,7 +330,7 @@ stored in the `w3m-favicon-image' buffer-local variable."
 						 "gzip -d" nil t))))
 		  (setq idata (buffer-string)
 			image (w3m-favicon-convert idata type)))
-	      (w3m-message "Reading %s...done (no favicon)"
+	      (w3m--message t t "Reading %s...done (no favicon)"
 			   (w3m-url-readable-string url)))
 	    (with-current-buffer target
 	      (w3m-favicon-set-image image)

--- a/w3m-fb.el
+++ b/w3m-fb.el
@@ -174,24 +174,26 @@ This allows frame-local lists of buffers (tabs)."
   :init-value nil
   :group 'w3m-fb
   :global t
-  (if (and w3m-fb-mode
-	   (if w3m-pop-up-frames
-	       (prog1
-		   (setq w3m-fb-mode nil)
-		 (message "\
-W3M Frame Buffer mode not activated (Hint: `M-x w3m-display-mode').")
-		 (sit-for 2))
-	     t))
-      (progn
-	(add-hook 'w3m-mode-hook 'w3m-fb-add)
-	(add-hook 'kill-buffer-hook 'w3m-fb-remove)
-	(when w3m-fb-delete-frame-kill-buffers
-	  (add-hook 'delete-frame-functions 'w3m-fb-delete-frame-buffers))
-	(w3m-fb-associate))
+  (cond
+   ((and w3m-fb-mode
+        (if w3m-pop-up-frames
+          (prog1
+            (setq w3m-fb-mode nil)
+            (w3m--message t 'w3m-error
+              "W3M Frame Buffer mode not activated (Hint: `M-x w3m-display-mode').")
+            (sit-for 2))
+         t))
+     (progn
+       (add-hook 'w3m-mode-hook 'w3m-fb-add)
+       (add-hook 'kill-buffer-hook 'w3m-fb-remove)
+       (when w3m-fb-delete-frame-kill-buffers
+         (add-hook 'delete-frame-functions 'w3m-fb-delete-frame-buffers))
+       (w3m-fb-associate)))
+   (t
     (remove-hook 'w3m-mode-hook 'w3m-fb-add)
     (remove-hook 'kill-buffer-hook 'w3m-fb-remove)
     (remove-hook 'delete-frame-functions 'w3m-fb-delete-frame-buffers)
-    (w3m-fb-dissociate)))
+    (w3m-fb-dissociate))))
 
 (provide 'w3m-fb)
 

--- a/w3m-filter.el
+++ b/w3m-filter.el
@@ -337,9 +337,10 @@ toggle with completion (a function toggled last will first appear)."
       ;; toggle state for all filters
       (progn
 	(setq w3m-use-filter (not w3m-use-filter))
-	(message (concat
-		  "web page filtering now "
-		  (if w3m-use-filter "enabled" "disabled"))))
+	(w3m--message t t
+          (concat
+            "web page filtering now "
+            (if w3m-use-filter "enabled" "disabled"))))
     ;; the remainder of this function if for the case of toggling
     ;; an individual filter
     (let* ((selection-list (delq nil (mapcar
@@ -363,9 +364,10 @@ toggle with completion (a function toggled last will first appear)."
 	    (setcar elem (not (car elem)))
 	    (when (car elem)
 	      (setq w3m-use-filter t))
-	    (message "filter `%s' now %s"
-		     choice
-		     (if (car elem) "enabled" "disabled"))))))))
+            (w3m--message t t
+              "filter `%s' now %s"
+              choice
+              (if (car elem) "enabled" "disabled"))))))))
 
 (defmacro w3m-filter-delete-regions (url start end
 					 &optional without-start without-end

--- a/w3m-form.el
+++ b/w3m-form.el
@@ -1006,7 +1006,7 @@ If optional REUSE-FORMS is non-nil, reuse it as `w3m-current-form'."
 
 (defun w3m-form-input-password (form id name)
   (if (get-text-property (point) 'w3m-form-readonly)
-      (message "This input box is read-only.")
+      (w3m--message t 'w3m-error "This input box is read-only.")
     (let* ((fvalue (w3m-form-get form id))
 	   (input (save-excursion
 		    (read-passwd (concat "PASSWORD"
@@ -1227,7 +1227,7 @@ character."
       (kill-buffer buffer)
       (if (not (buffer-live-p w3mbuffer))
 	  (and (eq this-command 'w3m-form-input-textarea-set)
-	       (message "No current w3m buffer"))
+	       (w3m--message t 'w3m-error "No current w3m buffer"))
 	(pop-to-buffer w3mbuffer)
 	(set-window-configuration wincfg)
 	(when (and form point)
@@ -1249,7 +1249,7 @@ character."
     (kill-buffer buffer)
     (if (not (buffer-live-p w3mbuffer))
 	(and (eq this-command 'w3m-form-input-textarea-exit)
-	     (message "No current w3m buffer"))
+	     (w3m--message t 'w3m-error "No current w3m buffer"))
       (pop-to-buffer w3mbuffer)
       (set-window-configuration wincfg)
       (when point (goto-char point)))))
@@ -1296,7 +1296,7 @@ positive, otherwise text-mode."
 	(if (null arg)
 	    (not w3m-form-textarea-use-org-mode-p)
 	  (> (prefix-numeric-value arg) 0)))
-  (message "Edit textarea in Org-mode %s"
+  (w3m--message t t "Edit textarea in Org-mode %s"
 	   (if w3m-form-textarea-use-org-mode-p "enabled" "disabled")))
 
 (eval-when-compile (require 'outline))

--- a/w3m-form.el
+++ b/w3m-form.el
@@ -993,7 +993,7 @@ If optional REUSE-FORMS is non-nil, reuse it as `w3m-current-form'."
 (defun w3m-form-input (form id name type width maxlength value)
   (let ((fvalue (w3m-form-get form id)))
     (if (get-text-property (point) 'w3m-form-readonly)
-	(w3m-message "READONLY %s: %s" (upcase type) fvalue)
+	(w3m--message nil 'w3m-warning "READONLY %s: %s" (upcase type) fvalue)
       (save-excursion
 	(let ((input (save-excursion
 		       (read-from-minibuffer (concat (upcase type) ": ") fvalue)))
@@ -1020,7 +1020,7 @@ If optional REUSE-FORMS is non-nil, reuse it as `w3m-current-form'."
 
 (defun w3m-form-input-checkbox (form id name value)
   (if (get-text-property (point) 'w3m-form-readonly)
-      (w3m-message "This form is currently inactive")
+      (w3m--message nil 'w3m-warning "This form is currently inactive")
     (let ((fvalue (w3m-form-get form id)))
       (if (member value fvalue)		; already checked
 	  (progn
@@ -1041,7 +1041,7 @@ If optional REUSE-FORMS is non-nil, reuse it as `w3m-current-form'."
 
 (defun w3m-form-input-radio (form id name value)
   (if (get-text-property (point) 'w3m-form-readonly)
-      (w3m-message "This form is currently inactive")
+      (w3m--message nil 'w3m-warning "This form is currently inactive")
     (save-excursion
       (let ((fid (w3m-form-field-parse
 		  (get-text-property (point) 'w3m-form-field-id)))
@@ -1065,7 +1065,7 @@ If optional REUSE-FORMS is non-nil, reuse it as `w3m-current-form'."
 
 (defun w3m-form-input-file (form id name value)
   (if (get-text-property (point) 'w3m-form-readonly)
-      (w3m-message "This form is currently inactive")
+      (w3m--message nil 'w3m-warning "This form is currently inactive")
     (let ((input (save-excursion
 		   (read-file-name "File name: "
 				   (or (cdr (w3m-form-get form id))
@@ -1346,11 +1346,11 @@ positive, otherwise text-mode."
 				     View-leave View-quit View-quit-all))
 	  (substitute-key-definition command
 				     'w3m-form-input-textarea-exit keymap))
-	(w3m-message (substitute-command-keys "READONLY TEXT; type \
+	(w3m--message nil 'w3m-warning (substitute-command-keys "READONLY TEXT; type \
 `\\<w3m-form-input-textarea-map>\\[w3m-form-input-textarea-exit]' \
 to quit textarea")))
     (w3m-form-input-textarea-mode 1)
-    (w3m-message "%s"
+    (w3m--message nil 'w3m-warning "%s"
 		 (if readonly "\
 This text is not editable because the form has disabled or readonly attribute"
 		   (substitute-command-keys "Type \
@@ -1704,7 +1704,7 @@ selected rather than \(as usual\) some other window.  See
 
 (defun w3m-form-input-select (form id name)
   (if (get-text-property (point) 'w3m-form-readonly)
-      (w3m-message "This form is currently inactive")
+      (w3m--message nil 'w3m-warning "This form is currently inactive")
     (let* ((value (w3m-form-get form id))
 	   (cur-win (selected-window))
 	   (wincfg (current-window-configuration))
@@ -2008,7 +2008,7 @@ selected rather than \(as usual\) some other window.  See
 			    url
 			  (concat (w3m-url-strip-query url) "?" query)))))
 	    (t
-	     (w3m-message "This form's method has not been supported: %s"
+	     (w3m--message nil 'w3m-error "This form's method is not supported: %s"
 			  (let (print-level print-length)
 			    (prin1-to-string (w3m-form-method form)))))))))
 

--- a/w3m-hist.el
+++ b/w3m-hist.el
@@ -596,8 +596,8 @@ added to the global properties instead."
 	    (unless (car properties) ;; check whether it is `(nil nil)'.
 	      (setq properties nil))
 	    (setcdr (cddr element) properties))
-	(message "\
-Warning: the history database in this session seems corrupted.")
+	(w3m--message t 'w3m-warning
+          "Warning: the history database in this session seems corrupted.")
 	(sit-for 1)
 	nil))))
 
@@ -651,7 +651,7 @@ position.  Naturally, those should be treated as buffer-local."
 	     :position (cons (count-lines (point-min) (point-at-bol)) column)
 	     :window-hscroll hscroll)))
     (when (w3m-interactive-p)
-      (message "The current cursor position saved"))))
+      (w3m--message t t "The current cursor position saved"))))
 
 (defun w3m-history-restore-position ()
   "Restore the saved cursor position in the page.
@@ -675,7 +675,7 @@ it works although it may not be perfect."
 	       (let ((deactivate-mark nil))
 		 (run-hooks 'w3m-after-cursor-move-hook))))
 	    ((w3m-interactive-p)
-	     (message "No cursor position saved"))))))
+	     (w3m--message t 'w3m-warning "No cursor position saved"))))))
 
 (defun w3m-history-minimize ()
   "Minimize the history so that there may be the current page only."
@@ -734,7 +734,7 @@ debugging w3m-hist.el.)"
 	     (prog1
 		 (yes-or-no-p
 		  "Are you sure you really want to destroy the history? ")
-	       (message "")))
+	       (message nil)))
     (setq w3m-history nil
 	  w3m-history-flat nil)
     (let ((w3m-history-reuse-history-elements t)

--- a/w3m-image.el
+++ b/w3m-image.el
@@ -123,7 +123,7 @@ nil forcibly."
 	 t)
 	(t
 	 (when w3m-imagick-convert-program
-	   (message "ImageMagick's `convert' program is not available")
+	   (w3m--message t 'w3m-error "ImageMagick's `convert' program is not available")
 	   (sit-for 1))
 	 (setq w3m-imagick-convert-program nil
 	       w3m-resize-images nil)
@@ -163,7 +163,7 @@ nil forcibly."
       (if (and (numberp return)
 	       (zerop return))
 	  t
-	(message "Image conversion failed (code `%s')" return)
+	(w3m--message t 'w3m-error "Image conversion failed (code `%s')" return)
 	nil))))
 
 (defun w3m-imagick-convert-data (data from-type to-type &rest args)

--- a/w3m-proc.el
+++ b/w3m-proc.el
@@ -608,7 +608,7 @@ evaluated in a temporary buffer."
 		  "\\(?:Accept [^\n]+\n\\)*\\([^\n]+: accept\\? \\)(y/n)")
 		 (= (match-end 0) (point-max)))
 	    ;; SSL certificate
-	    (message "")
+	    (message nil)
 	    (let ((yn (w3m-process-y-or-n-p w3m-current-url (match-string 1))))
 	      (ignore-errors
 		(process-send-string process (if yn "y\n" "n\n"))

--- a/w3m-session.el
+++ b/w3m-session.el
@@ -317,14 +317,14 @@ buffer's url history."
 				  w3m-current-title)
 			    urls)))))
      (if (not urls)
-	 (message "%s: no buffers saved...done" title)
+	 (w3m--message t t "%s: no buffers saved...done" title)
        (setq len (length urls))
        (setq urls (nreverse urls))
        (when (assoc title sessions)
 	 (setq sessions (delq (assoc title sessions) sessions)))
        (setq sessions (cons (list title (current-time) urls cnum) sessions))
        (w3m-save-list w3m-session-file sessions)
-       (message "%s: %d buffer%s saved...done" title len (if (= len 1) "" "s"))
+       (w3m--message t t "%s: %d buffer%s saved...done" title len (if (= len 1) "" "s"))
        (when (and (setq buf (get-buffer " *w3m-session select*"))
 		  (get-buffer-window buf 'visible))
 	 (save-selected-window (w3m-session-select)))))))
@@ -535,7 +535,7 @@ Meant for use  with  `pre-command-hook' and `post-command-hook'."
 	title titles time times wid pos)
     (if (not sessions)
 	(progn
-	  (message "No saved session")
+	  (w3m--message t 'w3m-error "No saved session")
 	  (w3m-session-select-quit))
       (mapc (lambda (x)
 	      (setq title (format "%s[%d]" (nth 0 x) (length (nth 2 x))))
@@ -673,7 +673,7 @@ buffer in the current session."
   (let ((num (or arg (get-text-property (point) 'w3m-session-number)))
 	wheight)
     (if (consp num)
-	(message "This is not a session group.")
+	(w3m--message t 'w3m-error "This is not a session group.")
       (setq w3m-session-group-open num)
       (setq wheight
 	    (max (+ (length (caddr (nth num w3m-session-select-sessions))) 6)
@@ -743,7 +743,7 @@ being below or beside the main window."
 	   (save-selected-window
 	     (select-window window)
 	     (or (one-window-p t t) (delete-window window)))))
-       (message "No saved session")))))
+       (w3m--message t 'w3m-error "No saved session")))))
 
 (defun w3m-session-goto-session (session)
   "Goto URLs."
@@ -753,7 +753,7 @@ being below or beside the main window."
 	(i 0)
 	(w3m-async-exec (and w3m-async-exec-with-many-urls w3m-async-exec))
 	url cbuf buf pos history)
-    (message "Session goto(%s)..." title)
+    (w3m--message nil t "Session goto(%s)..." title)
     (while (setq url (car urls))
       (setq urls (cdr urls))
       (unless (stringp url)
@@ -772,7 +772,7 @@ being below or beside the main window."
       (setq i (1+ i)))
     (when (and cbuf (eq major-mode 'w3m-mode))
       (set-window-buffer (selected-window) cbuf))
-    (message "Session goto(%s)...done" title)))
+    (w3m--message t t "Session goto(%s)...done" title)))
 
 (defun w3m-session-rename (sessions num)
   "Rename an entry (either a session or a buffer).

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1505,7 +1505,7 @@ The value of DEFAULT is inserted into PROMPT."
 			   ((stringp str) (read str))))
 		(error nil)))
 	    (unless (numberp n)
-	      (message "Please enter a number.")
+	      (w3m--message t 'w3m-error "Please enter a number.")
 	      (sit-for 1)
 	      t)))
       n)))

--- a/w3m-weather.el
+++ b/w3m-weather.el
@@ -425,7 +425,7 @@
 	    (w3m-decode-buffer furl)
 	    (w3m-weather-run-filter-functions w3m-weather-filter-functions
 					      area furl no-cache handler))))
-    (w3m-message "Unknown URL: %s" url)
+    (w3m--message t 'w3m-error "Unknown URL: %s" url)
     nil))
 
 (defun w3m-weather-run-filter-functions (functions area url no-cache handler)

--- a/w3m-xmas.el
+++ b/w3m-xmas.el
@@ -372,7 +372,7 @@ Third optional argument SIZE is currently ignored."
       (w3m-process-do-with-temp-buffer
 	  (type (condition-case err
 		    (w3m-retrieve url nil no-cache nil referer handler)
-		  (error (message "While retrieving %s: %s" url err) nil)))
+		  (error (w3m--message t 'w3m-error "While retrieving %s: %s" url err) nil)))
 	(goto-char (point-min))
 	(when (w3m-image-type-available-p
 	       (setq type
@@ -959,7 +959,7 @@ necessarily solve the problem completely."
 		      (encode-coding-string string coding-system)
 		      coding-system)
 		     string)
-      (message "Warning: this text may cause coding-system problem."))
+      (w3m--message t 'w3m-warning "Warning: this text may cause coding-system problem."))
     t))
 
 (provide 'w3m-xmas)

--- a/w3m.el
+++ b/w3m.el
@@ -4324,49 +4324,36 @@ resizing an image."
   "Interactively resize IMAGE.
 If RATE is not given, use `w3m-resize-image-scale'.
 CHANGED-RATE is currently changed rate / 100."
-  (let ((char (w3m-static-if (featurep 'xemacs)
-		  (progn
-		    (w3m--message nil t
-		     "Resize: [+ =] enlarge [-] shrink [0] original [q] quit")
-		    (read-char-exclusive))
-		(read-char-exclusive
-		 (propertize
-		  "Resize: [+ =] enlarge [-] shrink [0] original [q] quit"
-		  'face 'w3m-lnum-minibuffer-prompt))))
-	(changed-rate (or changed-rate 1)))
-    (w3m-static-if (featurep 'xemacs)
-	(setq char (char-octet char)))
-    (while (memq char '(?+ ?- ?= ?0))
-      (cond ((memq char '(?+ ?=))
-	     (let ((percent (+ 100 (or rate
-				       w3m-resize-image-scale))))
-	       (w3m-resize-inline-image-internal image percent)
-	       (setq changed-rate (* changed-rate
-				     (/ percent 100.0)))))
-	    ((eq char ?-)
-	     (let ((percent (/ 10000.0 (+ 100 (if rate
-						  (if (> rate 99) 99
-						    rate)
-						w3m-resize-image-scale)))))
-	       (w3m-resize-inline-image-internal image percent)
-	       (setq changed-rate (* changed-rate
-				     (/ percent 100.0)))))
-	    ((eq char ?0)
-	     (w3m-resize-inline-image-internal image
-					       (/ 100.0 changed-rate))
-	     (setq changed-rate 1)))
-      (setq char
-	    (w3m-static-if (featurep 'xemacs)
-		(progn
-		  (w3m--message nil t
-		   "Resize: [+ =] enlarge [-] shrink [0] original [q] quit")
-		  (read-char-exclusive))
-	      (read-char-exclusive
-	       (propertize
-		"Resize: [+ =] enlarge [-] shrink [0] original [q] quit"
-		'face 'w3m-lnum-minibuffer-prompt))))
-      (w3m-static-if (featurep 'xemacs)
-	  (setq char (char-octet char))))))
+  (let* ((msg-prompt "Resize: [+ =] enlarge [-] shrink [0] original [q] quit")
+         (changed-rate (or changed-rate 1))
+         (rate (or (and rate (min rate 99)) w3m-resize-image-scale))
+         char)
+    (while
+      (cond
+       ((memq
+          (setq char
+            (w3m-static-if (featurep 'xemacs)
+              (progn
+                 (w3m--message nil t msg-prompt)
+                 (char-octet (read-char-exclusive)))
+             (read-char-exclusive
+               (propertize msg-prompt 'face 'w3m-lnum-minibuffer-prompt))))
+          '(?+ ?=))
+        (let ((percent (+ 100 rate)))
+          (w3m-resize-inline-image-internal image percent)
+          (setq changed-rate (* changed-rate
+                                (/ percent 100.0)))))
+       ((eq char ?-)
+        (let ((percent (/ 10000.0 (+ 100 rate))))
+          (w3m-resize-inline-image-internal image percent)
+          (setq changed-rate (* changed-rate
+                                (/ percent 100.0)))))
+       ((eq char ?0)
+        (w3m-resize-inline-image-internal image
+                                          (/ 100.0 changed-rate))
+        (setq changed-rate 1))
+       (t nil)))))
+
 
 (defun w3m-zoom-in-image (&optional rate)
   "Zoom in an image on the point.


### PR DESCRIPTION
+ Although the project created a function `w3m-message` to be used instead of `message`, the
   old function was still often being used.

+ New feature: messages can be timed-out, to avoid needing to call `(message nil)`.

+ New feature: messages can be fontified, since the project uses `w3m-message` to signal many
   types of indication, including  warnings and errors. Aside from a default message face, faces
   'w3m-error and 'w3m-warning were created.

+ The code base was inconsistent in how it cleared the echo area, sometimes using "", and
   sometimes using `nil`, so it was standardized to use `nil`.