### PR TITLE
Make w3mhack-insert-git-revision not fail without git

### DIFF
--- a/w3mhack.el
+++ b/w3mhack.el
@@ -943,17 +943,18 @@ NOTE: This function must be called from the top directory."
 
 (defun w3mhack-insert-git-revision ()
   (let ((revision
-	 (with-temp-buffer
-	   (when (and (file-exists-p ".git/config")
-		      (executable-find "git")
-		      (zerop (call-process "git"
-					   nil
-					   t
-					   nil
-					   "log" "--oneline" "-n" "1" ".")))
-	     (goto-char (point-min))
-	     (skip-chars-forward "^ ")
-	     (concat "\"" (buffer-substring (point-min) (point)) "\"")))))
+	 (or (with-temp-buffer
+	       (when (and (file-exists-p ".git")
+		          (executable-find "git")
+		          (zerop (call-process "git"
+					       nil
+					       t
+					       nil
+					       "log" "--oneline" "-n" "1" ".")))
+	         (goto-char (point-min))
+	         (skip-chars-forward "^ ")
+	         (concat "\"" (buffer-substring (point-min) (point)) "\"")))
+             "unknown")))
     (goto-char (point-max))
     (while (progn
 	     (forward-line -1)


### PR DESCRIPTION
Please verify that using "unknown" is ok.
Also I do think that checking for .git instead of .git/config is enough.