### PR TITLE
Fix / note compiler warnings and errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-02-26  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-filter.el (w3m-filter-replace-regexp)
+	(w3m-filter-delete-regions), w3mhack.el:Fix byte-compile warnings.
+
+	* w3m-ucs.el: Un-fixed compiler warning noted.
+
 2019-02-25  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-favicon.el (w3m-favicon-convert): bugfix: check string bounds

--- a/w3m-filter.el
+++ b/w3m-filter.el
@@ -394,7 +394,7 @@ COUNT is the maximum number of deletions to make."
 			     '(match-beginning 0)
 			   '(match-end 0)))
        (setq i (1+ i)))
-     (> i 0)))
+     (setq i (> i 0))))
 
 (defmacro w3m-filter-replace-regexp (url regexp to-string
 					 &optional start-pos end-pos count)
@@ -410,7 +410,7 @@ the replacements."
 	       `#1#)
        (replace-match ,to-string nil nil)
        (setq i (1+ i)))
-     (> i 0)))
+     (setq i (> i 0))))
 
 ;; Filter functions:
 (defun w3m-filter-google-click-tracking (url)

--- a/w3m-ucs.el
+++ b/w3m-ucs.el
@@ -43,12 +43,16 @@
 	(defvar font-ccl-encoder-alist nil)
 	(require 'un-define))))
 
-(require 'un-define)
+; (require 'un-define)
 (require 'w3m-ccl)
 
 (eval-and-compile
   (autoload 'w3m-make-ccl-coding-system "w3m"))
 
+; FIXME: This function is separately and differently defined once in
+; file w3m-ems, and (get this) FIVE times in file w3m-xmas.el !! This
+; version of the definition raises a compiler warning "function
+; ‘ucs-to-char’ is not known to be defined."
 (defun w3m-ucs-to-char (codepoint)
   (condition-case nil
       (or (ucs-to-char codepoint) ?~)

--- a/w3mhack.el
+++ b/w3mhack.el
@@ -70,7 +70,10 @@ nil means that all icons are installed to the default directory.")
   "*Non-nil means that print the commands to install programs and datas,
 but do not execute them.")
 
-(require 'cl)
+(eval-when-compile
+  (require 'cl)
+  (require 'texinfmt))
+
 (condition-case nil (require 'seq) (error))
 
 ;; Check whether the shell command can be used.
@@ -368,22 +371,23 @@ Error: You have to install APEL before building emacs-w3m, see manuals.
   (dolist (module (w3mhack-module-list))
     (princ (format "%sc " module))))
 
-(if (featurep 'emacs)
-    (defun w3mhack-compile-file (file)
-      "Byte-compile FILE after reporting that it's being compiled."
-      ;; The byte compiler in Emacs >=25 doesn't say much.
-      (message "Compiling %s..." (file-name-nondirectory file))
-      (if (string-equal (file-name-nondirectory file) "w3m-filter.el")
-	  ;; Silence the warning "value returned from (> i 0) is unused".
-	  ;; See `w3m-filter-delete-regions', `w3m-filter-replace-regexp',
-	  ;; and the filter functions that use those macros.
-	  (let ((val (get '> 'side-effect-free)))
-	    (put '> 'side-effect-free 'error-free)
-	    (unwind-protect
-		(byte-compile-file file)
-	      (put '> 'side-effect-free val)))
-	(byte-compile-file file)))
-  (defalias 'w3mhack-compile-file 'byte-compile-file))
+(eval-when-compile
+  (if (featurep 'emacs)
+      (defun w3mhack-compile-file (file)
+        "Byte-compile FILE after reporting that it's being compiled."
+        ;; The byte compiler in Emacs >=25 doesn't say much.
+        (message "Compiling %s..." (file-name-nondirectory file))
+        (if (string-equal (file-name-nondirectory file) "w3m-filter.el")
+  	  ;; Silence the warning "value returned from (> i 0) is unused".
+  	  ;; See `w3m-filter-delete-regions', `w3m-filter-replace-regexp',
+  	  ;; and the filter functions that use those macros.
+  	  (let ((val (get '> 'side-effect-free)))
+  	    (put '> 'side-effect-free 'error-free)
+  	    (unwind-protect
+  		(byte-compile-file file)
+  	      (put '> 'side-effect-free val)))
+  	(byte-compile-file file)))
+    (defalias 'w3mhack-compile-file 'byte-compile-file)))
 
 (defun w3mhack-compile ()
   "Byte-compile the w3m modules."
@@ -442,7 +446,8 @@ Error: You have to install APEL before building emacs-w3m, see manuals.
 
 ;; Byte optimizers and version specific functions.
 (condition-case nil
-    (char-after)
+  (let (dummy-var-needed-to-avoid-compiler-warning)
+    (setq dummy-var-needed-to-avoid-compiler-warning (char-after)))
   (wrong-number-of-arguments
    (put 'char-after 'byte-optimizer
 	(lambda (form)
@@ -451,7 +456,8 @@ Error: You have to install APEL before building emacs-w3m, see manuals.
 	    '(char-after (point)))))))
 
 (condition-case nil
-    (char-before)
+  (let (dummy-var-needed-to-avoid-compiler-warning)
+    (setq dummy-var-needed-to-avoid-compiler-warning (char-before)))
   (wrong-number-of-arguments
    (put 'char-before 'byte-optimizer
 	(lambda (form)


### PR DESCRIPTION
* Look in file w3m-ucs.el at the defun for w3m-ucs-to-char.

  This function is separately and differently defined once in file
  w3m-ems, and (get this) FIVE times in file w3m-xmas.el !! This
  version of the definition raises a compiler warning "function
  ‘ucs-to-char’ is not known to be defined."