### PR TITLE
bugfix: makefile would crash when no git files exist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-02-26  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3mhack.el (w3mhack-insert-git-revision): bugfix: Only define the
+	constant emacs-w3m-git-revision when a git revision is found.
+
 2019-02-25  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-favicon.el (w3m-favicon-convert): bugfix: check string bounds

--- a/w3mhack.el
+++ b/w3mhack.el
@@ -954,16 +954,17 @@ NOTE: This function must be called from the top directory."
 	     (goto-char (point-min))
 	     (skip-chars-forward "^ ")
 	     (concat "\"" (buffer-substring (point-min) (point)) "\"")))))
-    (goto-char (point-max))
-    (while (progn
-	     (forward-line -1)
-	     (looking-at ";")))
-    (forward-line 1)
-    (insert "
+    (when revision
+      (goto-char (point-max))
+      (while (progn
+  	     (forward-line -1)
+  	     (looking-at ";")))
+      (forward-line 1)
+      (insert "
 (defconst emacs-w3m-git-revision " revision "
   \"Git revision string of this package.\")
 
-")))
+"))))
 
 (defun w3mhack-generate-load-file ()
   "Generate a file including all autoload stubs."


### PR DESCRIPTION
* The insert command here at the end of function
  w3mhack-insert-git-revision doesn't check whether variable revision
  is nil (eg. (or revision ""), but even if it did there would be no
  point since the only time the generated constant is used is in file
  w3m-bug.el where it is only used after checking that the symbol is
  bound, so not creating it here satisfies the situation there.