### PR TITLE
Change the order of show-this-line in w3m-select-buffer-delete-buffer

### DIFF
--- a/w3m.el
+++ b/w3m.el
@@ -11351,9 +11351,9 @@ without prompting for confirmation."
       (run-hooks 'w3m-delete-buffer-hook)
       (w3m-select-buffer-generate-contents
        (w3m-select-buffer-current-buffer))
-      (w3m-select-buffer-show-this-line)
       (goto-char (min pos (point-max)))
-      (beginning-of-line))))
+      (beginning-of-line)
+      (w3m-select-buffer-show-this-line))))
 
 (defun w3m-select-buffer-delete-other-buffers ()
   "Delete emacs-w3m buffers except for the buffer on the current menu."

--- a/w3m.el
+++ b/w3m.el
@@ -11339,8 +11339,9 @@ was called to terminate the emacs-w3m session.  In this case, the
 optional prefix argument FORCE can be set non-nil to exit the session
 without prompting for confirmation."
   (interactive "P")
-  (let ((pos (point))
-	(buffer (w3m-select-buffer-show-this-line)))
+  (let* ((pos (point))
+	 (buffer (w3m-select-buffer-current-buffer))
+         (show-next (eq (window-buffer w3m-select-buffer-window) buffer)))
     (if (= 1 (count-lines (point-min) (point-max)))
 	(w3m-quit force)
       (w3m-process-stop buffer)
@@ -11353,7 +11354,8 @@ without prompting for confirmation."
        (w3m-select-buffer-current-buffer))
       (goto-char (min pos (point-max)))
       (beginning-of-line)
-      (w3m-select-buffer-show-this-line))))
+      (when show-next
+        (w3m-select-buffer-show-this-line)))))
 
 (defun w3m-select-buffer-delete-other-buffers ()
   "Delete emacs-w3m buffers except for the buffer on the current menu."


### PR DESCRIPTION
Hi,

I'd like to put the call to `w3m-select-buffer-show-this-line` in `w3m-select-buffer-delete-buffer` after the call to `goto-char` so that the buffer on the current menu line is shown at the end. Otherwise the first buffer in the menu is shown, while the point has already moved.