### PR TITLE
BUGFIX: allow new tabs to be loaded in background

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2019-04-15  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el bugfixes to allow loading new tabs in background.
+	(w3m-goto-url-new-session): add optional arg NO-POPUP; replace
+	undocumented use of prefix-arg for RELOAD, with toggle of default
+	NO-POPUP value.
+	(w3m-copy-buffer): allow tab load in background; remove duplicate arg
+	JUST-COPY, major efficiency gains by using clone-buffer instead of
+	repeating entire w3m processing; replace undocumented use of prefix-arg
+	for renaming new copy, with toggle of default BACKGROUND value.
+	(w3m--goto-url--valid-url): adjust args for new format of
+	w3m-copy-buffer.
+	(w3m-view-this-url-1): pass arg NO-POPUP to allow tab
+	load in background.
+
 2019-04-14  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (emacs-w3m-version, w3m-version): Doc fix ([emacs-w3m:13330]).


### PR DESCRIPTION
+ This required adding an optional arg to w3m-goto-url-new-session,
  and combining two duplicate and badly-used args (JUST-COPY and
  BACKGROUND) in w3m-copy-buffer.

+ Both functions w3m-goto-url-new-session and w3m-copy-buffer had
  undocumented use of the prefix arg. These were changed to allow
  interactive toggling the default for loading in background or
  foreground.

  + w3m-copy-buffer was using prefix arg for renaming a tab copy

  + w3m-goto-url-new-session was using prefix-arg for RELOAD.

+ Combining args for w3m-copy-buffer meant adjusting a few calls to
  that function.

+ w3m-copy-buffer was changed to perform a buffer-clone instead of an
  entire w3m processing operation. This greatly speeds up response
  time.

+ There remains a seeming inconsistency in terminology in that it
  seems NO-POPUP and BACKGROUND are arg labels indentical in function.

+ See also mailing list [13345]