### PR TITLE
Prevent META refresh when Google searching

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-17  Tatsuya Kinoshita  <tats@debian.org>
+
+	* w3m-search.el (w3m-search-engine-alist): Add &gbv=1 to
+	www.google.com/search to prevent META refresh ([emacs-w3m:13355]).
+
 2019-04-14  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (emacs-w3m-version, w3m-version): Doc fix ([emacs-w3m:13330]).

--- a/w3m-search.el
+++ b/w3m-search.el
@@ -88,29 +88,29 @@
       ,@(cond
 	 ((and ja utf-8)
 	  '(("google"
-	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=utf-8&oe=utf-8"
+	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=utf-8&oe=utf-8&gbv=1"
 	     utf-8)
 	    ("google-en"
-	     "https://www.google.com/search?q=%s&hl=en&ie=utf-8&oe=utf-8"
+	     "https://www.google.com/search?q=%s&hl=en&ie=utf-8&oe=utf-8&gbv=1"
 	     utf-8)))
 	 (ja
 	  '(("google"
-	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=Shift_JIS&oe=Shift_JIS"
+	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=Shift_JIS&oe=Shift_JIS&gbv=1"
 	     shift_jis)
 	    ("google-en"
-	     "https://www.google.com/search?q=%s&hl=en")))
+	     "https://www.google.com/search?q=%s&hl=en&gbv=1")))
 	 (utf-8
 	  '(("google"
-	     "https://www.google.com/search?q=%s&ie=utf-8&oe=utf-8"
+	     "https://www.google.com/search?q=%s&ie=utf-8&oe=utf-8&gbv=1"
 	     utf-8)
 	    ("google-en"
-	     "https://www.google.com/search?q=%s&hl=en&ie=utf-8&oe=utf-8"
+	     "https://www.google.com/search?q=%s&hl=en&ie=utf-8&oe=utf-8&gbv=1"
 	     utf-8)))
 	 (t
 	  '(("google"
-	     "https://www.google.com/search?q=%s")
+	     "https://www.google.com/search?q=%s&gbv=1")
 	    ("google-ja"
-	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=Shift_JIS&oe=Shift_JIS"
+	     "https://www.google.com/search?q=%s&hl=ja&lr=lang_ja&ie=Shift_JIS&oe=Shift_JIS&gbv=1"
 	     shift_jis))))
       ,@(cond
 	 ((and ja utf-8)


### PR DESCRIPTION
* w3m-search.el (w3m-search-engine-alist): Add &gbv=1 to
www.google.com/search to prevent META refresh ([emacs-w3m:13355]).