### PR TITLE
Fix: w3m-insert-string modifies string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-05-03  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
+
+	* w3m-util.el (w3m-insert-string): Don't touch unibyte string.
+	encode-coding-string may modify unibyte string.
+
 2019-04-17  Tatsuya Kinoshita  <tats@debian.org>
 
 	* w3m-search.el (w3m-search-engine-alist): Add &gbv=1 to

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1356,9 +1356,10 @@ pairs from PLIST whose value is nil."
 multibyteness of the buffer."
   (if (featurep 'emacs)
       `(let ((string ,string))
-	 (insert (if enable-multibyte-characters
-		     string
-		   (encode-coding-string string 'utf-8-emacs))))
+	 (insert (if (and (null enable-multibyte-characters)
+			  (multibyte-string-p string))
+		     (encode-coding-string string 'utf-8-emacs)
+		   string)))
     `(insert ,string)))
 
 (defun w3m-custom-hook-initialize (symbol value)


### PR DESCRIPTION
encode-coding-string may modify unibyte string.

```lisp
(let ((string (string-to-unibyte "\300\261")))
  (encode-coding-string string 'utf-8-emacs))

-> "\261"
```