### PR TITLE
New feature: support torrent/magnet links (transmission front-end)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-05-05  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m--goto-torrent-url): New feature to support torrent and
+	magnet links, using for now external programs from the `transmission' suite.
+	(w3m-goto-url): Integrate the new feature.
+
 2019-04-17  Tatsuya Kinoshita  <tats@debian.org>
 
 	* w3m-search.el (w3m-search-engine-alist): Add &gbv=1 to


### PR DESCRIPTION
Now, pressing RETURN on a torrent or magnet link starts downloading the torrent, just like in all other browsers! As is the case for other browsers, an external program is used for the actual work. In this case, I chose the `transmission` project to do the heavy-lifting because it had a convenient set of command-line utilities including a daemon, and an NCURSES-based interface that was able to be launched within an emacs `ansi-term` buffer (see man(1) transmission-remote-cli for all its keybinding and configuration options).