### PR TITLE
w3m--goto-torrent-url: don't require transmission-remote-cli

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-05-06  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m--goto-torrent-url): Change dependency
+	`transmission-remote-cli' from required to recommended, and update
+	documentation accordingly.
+
 2019-05-05  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (w3m--goto-torrent-url): New feature to support torrent and


### PR DESCRIPTION
Change `transmission-remote-cli' from required to recommended, and update documentation accordingly.

This is a follow-up to PR #37. Before merging this PR, there may be a need to make another commit here to change use of `w3m--message` to `w3m-message` (ref PR #14).