### PR TITLE
Preserve session buffer/window and don't create duplicate buffers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,8 @@
 	* w3m-session.el (w3m-session-select-select): Don't quit after each
 	individual session action.
 	(w3m-session-goto-session): Preserve session buffer in its window, use
-	w3m version of message function, remove needless nreverse
+	w3m version of message function, remove needless nreverse, do not
+	create duplicate buffers.
 
 2019-05-09  Boruch Baum  <boruch_baum@gmx.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-05-19  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-session.el (w3m-session-select-select): Don't quit after each
+	individual session action.
+	(w3m-session-goto-session): Preserve session buffer in its window, use
+	w3m version of message function, remove needless nreverse
+
 2019-05-09  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-bookmark.el (w3m-bookmark-add): Bugfix: Order of args to function

--- a/w3m-session.el
+++ b/w3m-session.el
@@ -770,7 +770,7 @@ url will be created, only if it does not already exist."
     (when (not cwin)
       (error "No visible w3m windows found."))
     (with-selected-window cwin
-      (w3m--message t t "Session goto(%s)..." title)
+      (w3m-message "Session goto(%s)..." title)
       (while (setq url (pop urls))
         (unless (stringp url)
           (setq pos     (nth 1 url)
@@ -792,7 +792,7 @@ url will be created, only if it does not already exist."
     (set-window-buffer session-win session-buf)
     (when cbuf
       (set-window-buffer cwin cbuf))
-    (w3m--message t t "Session goto(%s)...done" title)))
+    (w3m-message "Session goto(%s)...done" title)))
 
 (defun w3m-session-rename (sessions num)
   "Rename an entry (either a session or a buffer).


### PR DESCRIPTION
This PR fixes three bugs with session management:

+ When opening a session or one of its elements:

  + don't quit the session buffer; allow the user to continue working
    on it.

  + don't forget the window in which the w3m session buffer was being
    displayed.

  + don't create duplicate buffers