### PR TITLE
w3m-search-name-anchor: make function more useful interactively

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-06-06  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m--get-page-anchors): New funcion.
+	(w3m-search-name-anchor): Prompt user interactively with list of
+	available anchors, excluding those from w3m half-dump. Provide this
+	function a keybinding `C-c j'.
+
 2019-05-28  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	Bugfix ([emacs-w3m:13417])

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-07-03  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m--filter-page-anchors): New feature to prune junk anchors
+	from anchor searches.
+	(w3m-anchor-list-filter-alist): Junk anchor defcustom.
+	(w3m--get-page-anchors): Implement the feature.
+
 2019-06-06  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (w3m--get-page-anchors): New funcion.


### PR DESCRIPTION
+ prompt user with list of available anchors, excluding those from w3m
	half-dump.

+ Add keybinding `C-c j'

+ Add ability to select from what data to generate anchor lists, and
  how to sort them.

This PR is a follow-up to post to the mailing list (13435 - 13438+]), but doesn't change the cumulative nature of the anchor data (at least not yet) To get an idea of how useful the feature is, try it out with the project homepage. To get an idea how much cruft it can collect and how difficult that can make using it, try it out on a wikipedia page (eg. the one for namazu). For users of interfaces such as ivy or helm or ido, the burden due to cruft can be manageable, but for other interactive users maybe it would be desirable to filter the list somehow. 

> (The original intent of the function was to allow a user to easily jump to any anchor on a page, from
any point on that page. The first two problems are that the user needs
to know the exact spelling of the anchor, and there's no way for a user
to know that without either looking at the page's raw html or buffer's
text properties. Let's use the project's own home page
(http://emacs-w3m.namazu.org/) as an example. If you tab through the
page's links, you'll notice subtle differences between each local-link's
label and the actual anchor (the actual link/anchor should appear in the
echo area when you tab to a link). In the case of this particular page,
the differences are capitalizations, but that's arbitrary.

>When looking at the internals, another weirdness appears: each anchor
for some reason is a list of itself and all the page's previous anchors.
