### PR TITLE
Properly handle local file URLs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2019-06-13  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-goto-url): bugfixes for local file urls: parse
+	environment variables in the pathname, honor docstring for
+	w3m-local-find-file-regexps.
+	(w3m-goto-url-new-session): bugfix for local file urls: don't hide
+	buffer after creating it.
+
+	* w3m-util.el (w3m-strip-queries): Add defcustom option to easily
+	toggle the feature.
+	(w3m--url-strip-queries): Use the defcustom.
+
 2019-06-07  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m.el (w3m-select-buffer-show-this-line)

--- a/w3m.el
+++ b/w3m.el
@@ -10024,26 +10024,24 @@ invoked in other than a w3m-mode buffer."
 	 (not (string= "text/html" (w3m-local-content-type url))))
     (w3m-goto-ftp-url url))
    ;; find-file directly
-   ((condition-case nil
-	(and (w3m-url-local-p url)
-	     w3m-local-find-file-function
-	     (let ((base-url (w3m-url-strip-fragment url))
-		   (match (car w3m-local-find-file-regexps))
-		   nomatch file)
-	       (and (or (not match)
-			(string-match match base-url))
-		    (not (and (setq nomatch (cdr w3m-local-find-file-regexps))
-			      (string-match nomatch base-url)))
-		    (setq file (w3m-url-to-file-name base-url))
-		    (file-exists-p file)
-		    (not (file-directory-p file))
-		    (prog1
-			t
-		      (funcall (if (functionp w3m-local-find-file-function)
-				   w3m-local-find-file-function
-				 (eval w3m-local-find-file-function))
-			       file)))))
-      (error nil)))
+   ((and (w3m-url-local-p url)
+         w3m-local-find-file-function
+         (setq url (concat "file:/" (substitute-in-file-name url)))
+         (let ((base-url (w3m-url-strip-fragment url))
+               (match (car w3m-local-find-file-regexps))
+               nomatch file)
+           (and (or (not match)
+                    (string-match match base-url))
+                (not (and (setq nomatch (cdr w3m-local-find-file-regexps))
+                          (string-match nomatch base-url)))
+                (setq file (w3m-url-to-file-name base-url))
+                (file-exists-p file)
+                (not (file-directory-p file))
+                (funcall (if (functionp w3m-local-find-file-function)
+                               w3m-local-find-file-function
+                             (eval w3m-local-find-file-function))
+                           file))))
+     t)
    ;; process buffer-local url
    ((w3m-buffer-local-url-p url)
     (let (file-part fragment-part)
@@ -10199,6 +10197,7 @@ buffer will start afresh."
 	    (match-beginning 8)
 	    'redisplay))
        charset post-data referer nil nil no-popup)
+      (pop-to-buffer buffer)
       ;; Delete useless newly created buffer if it is empty.
       (w3m-delete-buffer-if-empty buffer))))
 


### PR DESCRIPTION
This PR fixes several bugs in the handling of local file URLS:

+ Expands environment variables (eg. $HOME, $TEMPDIR, ~)

+ Respects documentation for w3m-local-find-file-regexps, in terms of
  what the included and excluded regexes do.

+ Doesn't hide a new find-file buffer when creating it using function
  w3m-goto-url-new-session.