### PR TITLE
w3m-session: bugfixes and new feature 'copy a session'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2019-06-14  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-session.el (w3m-session-select-delete): Advance to next session
+	group element after delete, not previous. Handle case of final entry of
+	session group being deleted.
+	(w3m-session-delete): Deleting final element of a session removes the
+	session entry itself, and returns to the parent page (ie. the list of
+	sessions, not the list of session elements).
+	(w3m-session-save): Remove catch/throw idiom
+	(w3m-session-select-copy): New feaure.
+	(w3m-session-select-mode-map): Bind new feature to 'c' and 'C'.
+	(w3m-session-select-quit): Properly position point upon completion.
+
 2019-06-07  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m.el (w3m-select-buffer-show-this-line)


### PR DESCRIPTION
+ w3m-session-select-copy: New feaure, bound to 'c' and 'C'.

+ Bugfixes: w3m-session-select-delete

  + Advance to next session group element after delete, not previous.

  + Handle case of final entry of	session group being deleted.

+ Bugfix: w3m-session-delete: Deleting final element of a session
	removes the session entry itself, and returns to the parent
	page (ie. the list of sessions, not the list of session elements).

+ Bugfix: w3m-session-select-quit: Properly position point upon
  completion.

+ w3m-session-save: Remove catch/throw idiom