### PR TITLE
new feature: toggle unread status of buffer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-06-16  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-select-buffer-toggle-unseen): New feature.
+	(w3m-select-buffer-mode-map): Bind new feature to 'u'.
+	(w3m-select-buffer-mode): Document new feature.
+
 2019-06-07  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m.el (w3m-select-buffer-show-this-line)

--- a/w3m.el
+++ b/w3m.el
@@ -11326,6 +11326,7 @@ The following command keys are available:
     (define-key map "p" 'w3m-select-buffer-previous-line)
     (define-key map "\C-c\C-n" 'w3m-select-buffer-move-next)
     (define-key map "\C-c\C-p" 'w3m-select-buffer-move-previous)
+    (define-key map "u" 'w3m-select-buffer-toggle-unseen)
     (define-key map "q" 'w3m-select-buffer-quit)
     (define-key map "h" 'w3m-select-buffer-show-this-line-and-switch)
     (define-key map "w" 'w3m-select-buffer-show-this-line-and-switch)
@@ -11369,6 +11370,8 @@ The following command keys are available:
 
 \\[w3m-select-buffer-toggle-style]\
 	Toggle the list style between horizontal and vertical.
+\\[w3m-select-buffer-toggle-unseen]\
+       Toggle the read/unread status of the selected buffer.
 
 \\[w3m-select-buffer-recheck]\
 	Refresh the list.
@@ -11556,6 +11559,20 @@ without prompting for confirmation."
   "Toggle the style of the selection between horizontal and vertical."
   (interactive)
   (w3m-select-buffer t))
+
+(defun w3m-select-buffer-toggle-unseen ()
+  "Toggle the read/unread status of a buffer."
+  (interactive)
+  (if (not (eq major-mode 'w3m-select-buffer-mode))
+    (w3m--message t 'w3m-warning
+      "This command is only available from the buffer selection pop-up window.")
+   (let ((pos (point)))
+     (with-current-buffer (w3m-select-buffer-current-buffer)
+       (if (w3m-unseen-buffer-p (current-buffer))
+         (w3m-set-buffer-seen)
+        (w3m-set-buffer-unseen)))
+     (w3m-select-buffer-generate-contents (current-buffer))
+     (goto-char pos))))
 
 (defun w3m-select-buffer-window-size ()
   (if w3m-select-buffer-horizontal-window


### PR DESCRIPTION
This is useful when using the buffer selection window to track your
buffers. For example, you can use it to mark a barely-'read' buffer
'unread' so you remember to come back to it and treat it freshly.