### PR TITLE
Fix for duckduckgo lite search engine

### DIFF
--- a/w3m-search.el
+++ b/w3m-search.el
@@ -214,7 +214,7 @@ __mk_ja_JP=%%83J%%83%%5E%%83J%%83i&url=search-alias%%3Daps&field-keywords=%s"
       ("ja.wikipedia" "https://ja.wikipedia.org/wiki/Special:Search?search=%s"
        utf-8)
       ("msdn" "https://search.msdn.microsoft.com/search/default.aspx?query=%s")
-      ("duckduckgo" "https://duckduckgo.com/lite" utf-8 "q=%s")))
+      ("duckduckgo" "https://duckduckgo.com/lite?q=%s" utf-8)))
   "*An alist of search engines.
 Each element looks like (ENGINE ACTION CODING POST-DATA)
 ENGINE is a string, the name of the search engine.


### PR DESCRIPTION
Current version does go to https://duckduckgo.com/lite , and doesn't use provided search query. Changed version does use provided query.