### PR TITLE
emulate 'awesome-bar' for bookmarked urls

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2019-06-30  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-input-url): Interpret bookmark titles as urls (ala
+	awesome-bar).
+	(w3m--get-url-from-bookmark-title): New function to enable the feature.
+	(w3m-arrived-setup): Add bookmark urls and title strings to
+	variable w3m-input-url-history.
+
 2019-06-07  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m.el (w3m-select-buffer-show-this-line)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-07-02  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-bookmark.el (w3m-bookmark-add, w3m-bookmark-add-all-urls): Add
+	new bookmarks to w3m-input-url-history for 'awesome bar' feature.
+
 2019-06-30  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (w3m-input-url): Interpret bookmark titles as urls (ala

--- a/w3m.el
+++ b/w3m.el
@@ -3061,7 +3061,9 @@ format, they will simply be ignored."
 (defun w3m-arrived-setup ()
   "Load the arrived URLs database file and set up the hashed database.
 It is performed only when `w3m-arrived-db' has not been initialize yet.
-The file is specified by `w3m-arrived-file'."
+The file is specified by `w3m-arrived-file'.
+
+This function also sets up `w3m-input-url-history'."
   (unless w3m-arrived-db
     (setq w3m-arrived-db (make-vector w3m-arrived-db-size 0))
     (let ((list (w3m-arrived-load-list)))
@@ -3077,7 +3079,18 @@ The file is specified by `w3m-arrived-file'."
 			   (when (stringp (nth 4 elem)) (nth 4 elem))
 			   (nth 5 elem))))
       (unless w3m-input-url-history
-	(setq w3m-input-url-history (mapcar (function car) list))))
+	(setq w3m-input-url-history
+          (let ((result))
+            (dolist (category (w3m-bookmark-iterator))
+              (dolist (entry (cdr category))
+                ;; bookmark url
+                (push (car entry) result)
+                ;; bookmark title
+                (push (replace-regexp-in-string "^[\s\t]+" ""
+                                                (cdr entry))
+                      result)))
+              (nconc (mapcar (function car) list) ;w3m-input-url-history
+                     result)))))
     (run-hooks 'w3m-arrived-setup-functions)))
 
 (defun w3m-arrived-shutdown ()
@@ -4714,6 +4727,26 @@ This function is used as `minibuffer-default-add-function'."
       (append def2 add2
 	      (delete def2 (delete def (delete add2 (delete to-add all))))))))
 
+(defun w3m--get-url-from-bookmark-title (url)
+  "Return the actual url of a bookmark title entered to `w3m-input-url'.
+If in response to function `w3m-input-url',a user entered a
+bookmark title string, replace it with that bookmark's url."
+  ;; TODO: Consider storing the flat bookmark data in memory instead
+  ;;       of constantly going to disk and re-evaluating it based upon
+  ;;       function `w3m-bookmark-iterator'.
+  (let ((bookmarks (w3m-bookmark-iterator))
+        category entry found)
+    (while (and (not found)
+                (setq category (cdr (pop bookmarks))))
+      (while (and (not found)
+                  (setq entry (pop category)))
+        (when (string= url
+                       (replace-regexp-in-string "^[\s\t]+" ""
+                                                 (cdr entry)))
+          (setq url (car entry))
+          (setq found t))))
+    url))
+
 (defun w3m-input-url (&optional prompt initial default quick-start
 				feeling-searchy no-initial)
   "Read a url from the minibuffer, prompting with string PROMPT."
@@ -4797,6 +4830,7 @@ This function is used as `minibuffer-default-add-function'."
 				   (prin1-to-string default)))
 		       (if feeling-searchy "URL or Keyword: " "URL: ")))
 		   initial keymap nil 'w3m-input-url-history default)))
+      (setq url (w3m--get-url-from-bookmark-title url))
       (if (string-equal url "")
 	  (or default "")
 	(if (stringp url)


### PR DESCRIPTION
+ All modern browsers already have this feature: the ability to type
  part of a bookmark url or even bookmark title, and have the browser
  auto-complete the input.

+ When a user is prompted for a URL, performing an i-search (C-r) now
  includes bookmarks.

  + Not just the bookmark urls, but also their titles. When a user
  selects a bookmark title, it is converted to that bookmark's url.