### PR TITLE
Don't byte-compile mime-w3m.el when SEMI is not installed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-07-17  Tatsuya Kinoshita  <tats@debian.org>
+
+	* w3mhack.el (w3mhack-module-list): Ignore `mime-w3m.el' when
+	`mime-view.el' is not found.
+
 2019-07-17  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	* w3m-favicon.el (w3m-favicon-type): Don't error out on Emacs-noX

--- a/w3mhack.el
+++ b/w3mhack.el
@@ -159,8 +159,9 @@ There seems to be no shell command which is equivalent to /bin/sh.
 		      (let ((load-path (list (file-name-directory gnus))))
 			(locate-library "nnimap"))))
 	    (push (concat shimbun-dir "nnshimbun.el") ignores)))
-      (push "mime-w3m.el" ignores)
       (push "octet.el" ignores))
+    (if (not (locate-library "mime-view"))
+        (push "mime-w3m.el" ignores))
     ;; List shimbun modules which cannot be byte-compiled with this system.
     (let (list)
       ;; Byte-compile w3m-util.el first.


### PR DESCRIPTION
When FLIM is installed and SEMI is not, `make` causes the
following error.

```
Compiling mime-w3m.el...

In toplevel form:
mime-w3m.el:37:1:Error: Cannot open load file: No such file or directory, mime-view
```

With the recent commit b5ec8774 on 2019-06-17, mime-w3m.el requires
SEMI's mime-view.el instead of FLIM's one, so I've added a check for
mime-view.el existence.
