### PR TITLE
Fix saving and restoring of a session

### DIFF
--- a/w3m-session.el
+++ b/w3m-session.el
@@ -313,7 +313,7 @@ buffer's url history."
 	     (setq cnum i))
 	   (setq i (1+ i))
 	   (setq urls (cons (list w3m-current-url
-				  (copy-sequence (caar w3m-history))
+				  (copy-sequence (cadar w3m-history))
 				  (w3m-session-history-to-save)
 				  w3m-current-title)
 			    urls)))))
@@ -853,7 +853,7 @@ url will be created, only if it does not already exist."
 		   (with-current-buffer x
 		     (cons w3m-current-url x)))
 		 (w3m-list-buffers)))
-	url cbuf cwin buf pos history)
+	url cbuf cwin buf pos history url-title)
     (dolist (win (window-list))
       (when (string-match "\\*w3m\\*" (buffer-name (window-buffer win)))
 	(setq cwin win)))
@@ -863,9 +863,10 @@ url will be created, only if it does not already exist."
       (w3m-message "Session goto(%s)..." title)
       (while (setq url (pop urls))
 	(unless (stringp url)
-	  (setq pos     (nth 1 url)
-		history (nth 2 url)
-		url     (nth 0 url)))
+	  (setq pos       (nth 1 url)
+		history   (nth 2 url)
+		url-title (nth 3 url)
+		url       (nth 0 url)))
 	(cond
 	 ((setq cbuf (cdr (assoc url w3m-urls))) t)
 	 (t ; ie. (not (assoc url w3m-urls))
@@ -876,6 +877,7 @@ url will be created, only if it does not already exist."
 	    (setq cbuf buf))
 	  (when (and buf pos history)
 	    (set-buffer buf)
+	    (push (list url (list :title url-title) pos) history) ;current
 	    (setq w3m-history-flat history)
 	    (w3m-history-tree pos))
 	  (setq i (1+ i))))))


### PR DESCRIPTION
I use long-lived sessions with many buffers and lots of history within
each.  Sometimes, when loading such a session, I get an error
(wrong-type-argument consp nil) or something like that.  I will not
report that exact problem here for now, because currently I don't have
such a session, and if I had it then it would be complex.

I took a look at the code responsible for saving/restoring sessions
and found two problems, which I believe take part in my original
problem.  What I plan is to live with these fixes for a while and see
if anything goes wrong again.  If I reproduce the original problem,
I'll try to report it with minimal test case.

So this PR contains fixes for the code which I'm sure is wrong in
master (assuming I'm not wrong when reading the code).

I had a test w3m session: "about" -> page1 -> page2 -> return to page
1 with 'B' -> page11 -> return to page 1 with 'B'.  Here I stop and
inspect variables, details are below.

I've replaced real urls/titles with page1 etc for brevity.

Value of w3m-history:

```lisp
(
 ((0) (1) (1 0 0))
 ;; pos = (0)
 ("about:" (:title "About emacs-w3m"))
 ;; pos = (1)
 ("page1.html" (:title "page1_title")
  ;; pos = (1 0 0)
  (("page11.html" (:title "page11_title"))))
 ;; pos = (2)
 ("page2.html" (:title "page2_title)"))
 )
```

Value of w3m-history-flat (buffer-local prop lists removed for brevity):

```lisp
(
 ("about:" (:title "About emacs-w3m")
  (0))
 ("page1.html" (:title "page1_title")
  (1))
 ("page2.html" (:title "page2_title)")
  (2))
 ("page11.html" (:title "page11_title")
  (1 0 0))
 )
```

Slimmed history view for saving in session is created
by (w3m-history-slimmed-history-flat), its output (buffer-local
prop lists are again removed for brevity) is correct:

```lisp
(
 ("page11.html" (:title "page11_title")
  (1 0 0))
 ("about:" (:title "About emacs-w3m")
  (0))
 ("page1.html" (:title "page1_title")
  (1))
 )
```

So finally, what is saved in .sessions file.  Session format
is (title time ((url pos history-flat urltitle) ..) current-num).

```lisp
("sess1"
 (23890 63354 188029 0)
 (
  ("page1.html"
 ; vvv BUG #1 (w3m-session-save): (0) is prev-pos; should be (1) for current
   (0)
   (
    ("page11.html" (:title "page11_title")
     (1 0 0))				;correct
    ("about:" (:title "About emacs-w3m")
     (0))				;correct
    )
   "page1_title"))
 0)
```

So the "current" position in slimmed history is written as (0),
and we have broken history of ((0) (0) (1 0 0)) which has gap,
instead of correct ((0) (1) (1 0 0)).

Assume this is fixed, and we have correct history.  Then goes the
bug #2: on session load, w3m-session-goto-session sets
buffer-local w3m-history-flat from saved value in session.  It
then invokes w3m-history-tree to rebuild w3m-history value from
flat history.  But the flat history value used doesn't include
the current page!  So even correct position (bug #1) would point
nowhere.

Thus the fix for bug #2 in w3m-session-goto-session.

Without the fixes, the w3m-history after loading this session would be:

```lisp
((nil (0) (0 0 0))			;WRONG current position
 ("about:" (:title "About emacs-w3m")
  (("page1.html" (:title "page1_title"))))
 (nil nil				;WRONG - these nils
      (("page11.html" (:title "page11_title")))))
```

And attempting to navigate it with N/B will see only first two pages.

With fixes, it is:

```lisp
(((0) (1) (1 0 0))
 ("about:" (:title "About emacs-w3m"))
 ("page1.html" (:title "page1_title")
  (("page11.html" (:title "page11_title")))))
```

And we see all 3 pages when navigating with N/B.
