### PR TITLE
Improve perldoc with customizable variable, and saner default.

### DIFF
--- a/w3m-perldoc.el
+++ b/w3m-perldoc.el
@@ -39,6 +39,12 @@
   :group 'w3m
   :prefix "w3m-perldoc-")
 
+
+(defcustom w3m-perldoc-base-url "https://perldoc.perl.org/"
+	"The URL domain base to lookup the perldoc with."
+	:group 'w3m-perldoc
+	:type 'string)
+
 (defcustom w3m-perldoc-command "perldoc"
   "Name of the executable file of perldoc."
   :group 'w3m-perldoc
@@ -113,13 +119,30 @@
 		   (insert "::"))
 		 (goto-char (point-max))))
 	     "text/html")))))
+(defun w3m-perldoc-pretty (string)
+	"Make a string more likely to find a perldoc page."
+	(flet ((swap (old new string)
+							 (let ((loc (search old string)))
+								 (if loc
+										 (concat (substring string 0 loc)
+														 new
+														 (swap old new (substring string
+																											(+ (length old) loc))))
+									 string))))
+		(concat (swap " " "/" (swap "::" "/" string))
+						(if (not (string= "" string))
+								".html"
+							"")
+						"#perl_version")))
+
+(defun w3m-ensure-url )
 
 ;;;###autoload
 (defun w3m-perldoc (docname)
   "View Perl documents."
   (interactive "sDocument: ")
-  (w3m-goto-url (concat "about://perldoc/" (w3m-url-encode-string docname))))
-
+  (w3m-goto-url (concat (w3m-ensure-slash w3m-perldoc-base-url)
+												(w3m-perldoc-pretty docname))))
 (provide 'w3m-perldoc)
 
 ;;; w3m-perldoc.el ends here.

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1583,6 +1583,12 @@ the function cell of FUNCs rather than their value cell.
 	  (buffer-substring-no-properties (point-min) (point-max))))
     url))
 
+(defun w3m-ensure-slash (url)
+	"Ensure that a URL ends in a /. Useful for concatenation purposes."
+	(if (string=  "/" (string (elt url (1- (length url)))))
+			url
+		(concat url "/")))
+
 (provide 'w3m-util)
 
 ;;; w3m-util.el ends here


### PR DESCRIPTION
Currently the `w3m-perldoc` command has the base URL `about://perldoc/` hardcoded into the function call. I added a `defcustom`, changed the default to `https://perldoc.perl.org/`, and added a function that attempts to cleanup user input in a way more likely to match a page.

Personally I am going to clone their github and have a local copy to lookup with, which is why I needed the URL to be customizable. Here is what I have in my config:
```emacs-lisp
(setq perl-version "5.30.0")
(setq w3m-perldoc-base-url (concat "file:///home/user/perl5/perldoc/"
                                   perl-version))
```

Try running:
`(w3m-perldoc "Pod Checker")`
which will send you off to https://perldoc.perl.org/Pod/Checker.html#perl_version
or
`(w3m-perldoc "Getopt::Long")`
TODO:
- Improve the cleanup to deal with other things (like case-sensitivity of the input), and query the user for more input when the page is 404.
- Support some kind of at-point function intended for use from a perl document.
