### PR TITLE
Fix document typo

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-18  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
+
+	* doc/emacs-w3m-ja.texi (Installing Emacs-w3m): Add dropped @samp
+	command for --without-compress-install option.
+
 2020-03-18  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	Make w3m-toggle-inline-image work properly when region is active

--- a/doc/emacs-w3m-ja.texi
+++ b/doc/emacs-w3m-ja.texi
@@ -353,7 +353,7 @@ Emacs-w3m を CVS で取得したのならば、@samp{configure} スクリプト
 デフォルトではインストーラ (つまり @samp{make install}) は gzip によって
 インストールされる Lisp のソースファイルと info ファイルを圧縮します。も
 しそれらのファイルが圧縮されることを望まないのであれば、configure オプショ
-ンの {--without-compress-install} を使ってください。
+ンの @samp{--without-compress-install} を使ってください。
 
 @item
 単に @samp{make} と @samp{make install} を実行します。


### PR DESCRIPTION
* doc/emacs-w3m-ja.texi (Installing Emacs-w3m): Add dropped @samp
command for --without-compress-install option.