### PR TITLE
Find/use 'next'/'prev' links not identified within HTML tags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-09-07  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-next-page-label, w3m-previous-page-label)
+	(w3m-scroll-up-or-next-url, w3m-scroll-down-or-previous-url):
+	Additional logic to catch 'next' and 'previous' page links not
+	identified within an HTML tag.
+	(w3m-scroll-interval, w3m-set-scroll-interval): New defcustom to set
+	default scroll interval for 'long scrolls'
+
 2020-09-03  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	Allow url like "file:foo.txt" (bug#969386 of debian)


### PR DESCRIPTION
+ w3m parses HTML tags to try to intelligently guess the 'next' and
  'previous' pages for a URL so it proceed there when a page beginning
  or end is reached. However, some/many website software don't embed
  that information within HTML tags, and they rely solely on the
  plain-text between the opening and closing HTML 'A' tag. An example
  of this is the sofwtare for the emacs mailing list archive! This
  commit adds logic to find and use that information.

+ This commit does introduce new behavior in the patched functions
  that change the meaning of the prefix-arg!

  + The most convenient way to give the user flexibility to change
    his/her mind about which text labels to use for navigation was to
    use the prefix-arg for two of the scroll commands. However, those
    functions were already using the prefix-arg for an option to
    scroll n lines instead of a screen-full. After giving the matter
    thought, it seemed to me that someone wanting finely-tuned
    scrolling could/should/was probably using two other functions
    anyway (w3m-scroll-up and w3m-scroll-down) which default to one
    line and have the optional prefix-arg for n lines.

+ Minimizing the effect of the behavior change

  + The commit adds a defcustom for number of default lines to scroll
    when not performing fine-tune scrolling (ie. when not using
    functions w3m-scroll-up and w3m-scroll-down). When that variable
    is NON-NIL, functions w3m-scroll-up-or-next-url and
    w3m-scroll-down-or-previous-url use that number instead of a
    screen-full.

  + The commit adds a function w3m-set-scroll-interval to conveniently
    change the default scroll amount of the defcustom, but only for
    the current session.

+ The result is that scrolling is more convenient because if you want
  someone who wants to scroll n lines instead of a screen-full will
  probably want to do that repeatedly. Without the patch, that user
  would need to use the prefix-arg and numeric entry for each scroll.
  With this commit, the user only needs to set the value once, and can
  do so as a command, without having to manually evaluate a variable.
  The use does need to remember or guess that in order to "set the w3m
  scroll interval" you perform M-x w3m-set-scroll-interval.

+ Benefit of logic at point-of-use. The logic is not performed during
  page parsing (all pages), only when the feature is needed (very
  rarely).