### PR TITLE
Set variable buffer-quit-function for -session and -select modes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-12-28  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-select-buffer-mode): Set variable buffer-quit-function.
+
+	* w3m-session.el (w3m-session-select-mode): Set variable
+	buffer-quit-function.
+
 2020-12-22  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-filter.el (w3m-filter-stackexchange): Update filter and correct

--- a/w3m-session.el
+++ b/w3m-session.el
@@ -509,6 +509,7 @@ buffer's url history."
 	   buffer-read-only nil
 	   major-mode 'w3m-session-select-mode
 	   w3m-session-select-sessions sessions
+           buffer-quit-function 'w3m-session-select-quit
 	   buffer-read-only t)
      (setq w3m-session-group-open nil)
      (use-local-map w3m-session-select-mode-map)

--- a/w3m.el
+++ b/w3m.el
@@ -11353,7 +11353,8 @@ The following command keys are available:
   (setq major-mode 'w3m-select-buffer-mode
 	mode-name "w3m buffers"
 	truncate-lines t
-	buffer-read-only t)
+	buffer-read-only t
+        buffer-quit-function 'w3m-select-buffer-quit)
   (use-local-map w3m-select-buffer-mode-map)
   (run-mode-hooks 'w3m-select-buffer-mode-hook))
 


### PR DESCRIPTION
  Variable buffer-quit-function is used by function
  keyboard-escape-quit to decide how to exit a buffer when pressing a
  keybinding such as ESC-ESC-ESC. Without setting the variable for the
  w3m-session and w3m-select modes, the action taken is to hide all
  the *other* windows on the current frame. This commit has it perform
  the modes' quit function.