### PR TITLE
BUGFIX: don't put about://history/ pages in history.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2021-01-03  Boruch Baum  <boruch_baum@gmx.com>
 
-	* w3m-hist.el (w3m-history-push): Don't put history pages in the history.
+	* w3m.el (w3m-view-previous-page): When currently in an "about://" url,
+	return to the calling url (PR#89 for upstream).
+
+	* w3m-hist.el (w3m-history-push): Don't put "about://" pages in the
+	history (PR#89 for upstream).
 
 2020-12-31  Boruch Baum  <boruch_baum@gmx.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,23 +6,6 @@
 	* w3m-hist.el (w3m-history-push): Don't put "about://" pages in the
 	history (PR#89 for upstream).
 
-2020-12-31  Boruch Baum  <boruch_baum@gmx.com>
-
-	* w3m.el (w3m-scroll-up-or-next-url, w3m-scroll-up): Ensure end of page
-	remains at bottom of window.
-
-2020-12-28  Boruch Baum  <boruch_baum@gmx.com>
-
-	* w3m.el (w3m-select-buffer-mode): Set variable buffer-quit-function.
-
-	* w3m-session.el (w3m-session-select-mode): Set variable
-	buffer-quit-function.
-
-2020-12-23  Boruch Baum  <boruch_baum@gmx.com>
-
-        * w3m.el (w3m--retrieve-1--handler-function): Fix Debian bug 933371 for
-	url queries.
-
 2020-12-22  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-filter.el (w3m-filter-stackexchange): Update filter and correct

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,24 @@
+2021-01-03  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-hist.el (w3m-history-push): Don't put history pages in the history.
+
+2020-12-31  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-scroll-up-or-next-url, w3m-scroll-up): Ensure end of page
+	remains at bottom of window.
+
+2020-12-28  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m.el (w3m-select-buffer-mode): Set variable buffer-quit-function.
+
+	* w3m-session.el (w3m-session-select-mode): Set variable
+	buffer-quit-function.
+
+2020-12-23  Boruch Baum  <boruch_baum@gmx.com>
+
+        * w3m.el (w3m--retrieve-1--handler-function): Fix Debian bug 933371 for
+	url queries.
+
 2020-12-22  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-filter.el (w3m-filter-stackexchange): Update filter and correct

--- a/w3m-hist.el
+++ b/w3m-hist.el
@@ -475,7 +475,7 @@ The case where `w3m-history-reuse-history-elements' is non-nil:
 If REPLACE is nil, NEWPROPS is merged into properties of the current
 history element.  Otherwise, properties of the current history element
 are replaced with NEWPROPS."
-  (unless (equal url "about://history/")
+  (unless (string-match "^about://" url)
     (let ((element (w3m-history-seek-element url newprops replace))
           position class number branch)
       (if element
@@ -496,7 +496,6 @@ are replaced with NEWPROPS."
         ;; visiting a page when moving back, moving forward or jumping from
         ;; the about://history/ page.
         (w3m-history-set-current position))
-
        (t
         ;; Sprout a new history element.
         (setq position (copy-sequence (cadar w3m-history))

--- a/w3m-hist.el
+++ b/w3m-hist.el
@@ -475,51 +475,52 @@ The case where `w3m-history-reuse-history-elements' is non-nil:
 If REPLACE is nil, NEWPROPS is merged into properties of the current
 history element.  Otherwise, properties of the current history element
 are replaced with NEWPROPS."
-  (let ((element (w3m-history-seek-element url newprops replace))
-	position class number branch)
-    (if element
-	(setcdr (cdr element) nil)
-      (setq element (list url (w3m-history-modify-properties newprops nil))))
-    (cond
-     ((null w3m-history)
-      ;; The dawn of the history.
-      (setq position (list nil (list 0) nil)
-	    w3m-history (list position element)
-	    w3m-history-flat (list (append element (list (list 0)))))
-      position)
+  (unless (equal url "about://history/")
+    (let ((element (w3m-history-seek-element url newprops replace))
+          position class number branch)
+      (if element
+          (setcdr (cdr element) nil)
+        (setq element (list url (w3m-history-modify-properties newprops nil))))
+      (cond
+       ((null w3m-history)
+        ;; The dawn of the history.
+        (setq position (list nil (list 0) nil)
+              w3m-history (list position element)
+              w3m-history-flat (list (append element (list (list 0)))))
+        position)
 
-     ((and w3m-history-reuse-history-elements
-	   (setq position (caddr (w3m-history-assoc url))))
-      ;; Reuse the existing history element assigned to the current one.
-      ;; The position pointers will be fixed with correct values after
-      ;; visiting a page when moving back, moving forward or jumping from
-      ;; the about://history/ page.
-      (w3m-history-set-current position))
+       ((and w3m-history-reuse-history-elements
+             (setq position (caddr (w3m-history-assoc url))))
+        ;; Reuse the existing history element assigned to the current one.
+        ;; The position pointers will be fixed with correct values after
+        ;; visiting a page when moving back, moving forward or jumping from
+        ;; the about://history/ page.
+        (w3m-history-set-current position))
 
-     (t
-      ;; Sprout a new history element.
-      (setq position (copy-sequence (cadar w3m-history))
-	    class (1- (length position))
-	    number 0
-	    branch (nthcdr (car position) (cdr w3m-history)))
-      (while (> class number)
-	(setq number (1+ number)
-	      branch (nth (nth number position) (cddar branch))
-	      number (1+ number)
-	      branch (nthcdr (nth number position) branch)))
-      (if (cdr branch)
-	  ;; We should sprout a new branch.
-	  (progn
-	    (setq number (1- (length (car branch))))
-	    (setcdr (nthcdr class position) (list (1- number) 0))
-	    (setcdr (nthcdr number (car branch)) (list (list element))))
-	;; The current position is the last of the branch.
-	(setcar (nthcdr class position)
-		(1+ (car (nthcdr class position))))
-	(setcdr branch (list element)))
-      (setq w3m-history-flat (nconc w3m-history-flat
-				    (list (append element (list position)))))
-      (setcar w3m-history (list (cadar w3m-history) position nil))))))
+       (t
+        ;; Sprout a new history element.
+        (setq position (copy-sequence (cadar w3m-history))
+              class (1- (length position))
+              number 0
+              branch (nthcdr (car position) (cdr w3m-history)))
+        (while (> class number)
+          (setq number (1+ number)
+                branch (nth (nth number position) (cddar branch))
+                number (1+ number)
+                branch (nthcdr (nth number position) branch)))
+        (if (cdr branch)
+            ;; We should sprout a new branch.
+            (progn
+              (setq number (1- (length (car branch))))
+              (setcdr (nthcdr class position) (list (1- number) 0))
+              (setcdr (nthcdr number (car branch)) (list (list element))))
+          ;; The current position is the last of the branch.
+          (setcar (nthcdr class position)
+          	(1+ (car (nthcdr class position))))
+          (setcdr branch (list element)))
+        (setq w3m-history-flat (nconc w3m-history-flat
+          			    (list (append element (list position)))))
+        (setcar w3m-history (list (cadar w3m-history) position nil)))))))
 
 (defun w3m-history-copy (buffer)
   "Copy the history structure from BUFFER to the current buffer.

--- a/w3m.el
+++ b/w3m.el
@@ -7029,46 +7029,55 @@ previous page."
     ;; This page may have not been registered in the history since an
     ;; accident has probably occurred, so we should skip the page.
     (if (integerp count)
-	(when (> count 0)
-	  (cl-decf count))
+        (when (> count 0)
+          (cl-decf count))
       (setq count 0)))
   (let ((index (car w3m-name-anchor-from-hist))
-	pos)
+        pos)
     (if (and (integerp count)
-	     (integerp index)
-	     (< 0 (setq index (+ index count)))
-	     (setq pos (nth index w3m-name-anchor-from-hist)))
-	(progn
-	  (when (and (= (point) pos)
-		     (nth (1+ index) w3m-name-anchor-from-hist))
-	    (setq index (1+ index)))
-	  (goto-char (nth index w3m-name-anchor-from-hist))
-	  (setcar w3m-name-anchor-from-hist index)
-	  ;; Restore last position.
-	  (w3m-history-restore-position))
+             (integerp index)
+             (< 0 (setq index (+ index count)))
+             (setq pos (nth index w3m-name-anchor-from-hist)))
+        (progn
+          (when (and (= (point) pos)
+                     (nth (1+ index) w3m-name-anchor-from-hist))
+            (setq index (1+ index)))
+          (goto-char (nth index w3m-name-anchor-from-hist))
+          (setcar w3m-name-anchor-from-hist index)
+          ;; Restore last position.
+          (w3m-history-restore-position))
       (let ((hist ;; Cons of a new history element and position pointers.
-	     (if (integerp count)
-		 (w3m-history-backward count)
-	       (w3m-history-backward)))
-	    ;; Inhibit sprouting of a new history.
-	    (w3m-history-reuse-history-elements t))
-	(if (caar hist)
-	    (let ((w3m-prefer-cache t))
-	      ;; Save last position.
-	      (or no-store-pos (w3m-history-store-position))
-	      (w3m-goto-url (caar hist) nil nil
-			    (w3m-history-plist-get :post-data)
-			    (w3m-history-plist-get :referer)
-			    nil
-			    (w3m-history-element (caddr hist) t))
-	      ;; Set the position pointers in the history.
-	      (setcar w3m-history (cdr hist))
-	      ;; Restore last position.
-	      (w3m-history-restore-position))
-	  (if (and (equal w3m-current-url "about://cookie/")
-		   (> (length (w3m-list-buffers t)) 1))
-	      (w3m-delete-buffer)
-	    (w3m-message "There's no more history")))))))
+             (if (integerp count)
+                 (w3m-history-backward count)
+               (w3m-history-backward)))
+            ;; Inhibit sprouting of a new history.
+            (w3m-history-reuse-history-elements t))
+        (cond
+         ((caar hist)
+           (let ((w3m-prefer-cache t))
+             ;; Save last position.
+             (w3m-history-store-position)
+             (w3m-goto-url (caar hist) nil nil
+                    (w3m-history-plist-get :post-data)
+                    (w3m-history-plist-get :referer)
+                    nil
+                    (w3m-history-element (caddr hist) t))
+             ;; Set the position pointers in the history.
+             (setcar w3m-history (cdr hist))
+             ;; Restore last position.
+             (w3m-history-restore-position)))
+         ((and (equal w3m-current-url "about://cookie/")
+               (> (length (w3m-list-buffers t)) 1))
+           (w3m-delete-buffer))
+         ((string-match "^about://" w3m-current-url)
+           (setq hist (w3m-history-backward 0))
+           (w3m-goto-url (caar hist) nil nil
+                         (w3m-history-plist-get :post-data)
+                         (w3m-history-plist-get :referer)
+                         nil
+                         (w3m-history-element (caddr hist) t)))
+         (t
+           (w3m-message "There's no more history")))))))
 
 (defun w3m-view-next-page (&optional count)
   "Move forward COUNT pages in history.


### PR DESCRIPTION
This is a one-line addition to the beginning of function w3m-history-push. It prevents the about:history page from accumulating entries of itself. What otherwise happens is that each time someone presses 'h' another copy of the history is added to the history list for the buffer! Press 'h' and 'B' many times and you end up with many copies of the history in your buffer's history, when really it should appear ZERO times.