### PR TITLE
Fixes for w3m-current-url = NIL, loading images from ext program

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 	(w3m-image-page-displayed-p, w3m-view-previous-page)
 	(w3m--goto-url--handler-function): when w3m-current-url is NIL, don't
 	perform string operations on it.
+	(w3m-delete-buffer-if-empty): Only operate on live buffers.
 
 2021-03-29  Katsumi Yamaoka  <yamaoka@jpl.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2021-04-08  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-proc.el (w3m-process-stop): Add optional arg to kill the current buffer.
+	* w3m.el (w3m--goto-url--valid-url): Use it.
+	(w3m-toggle-inline-images): Don't let user-error start a backtrace when
+	toggle-debug-on-error is set.
+	(w3m-image-page-displayed-p, w3m-view-previous-page)
+	(w3m--goto-url--handler-function): when w3m-current-url is NIL, don't
+	perform string operations on it.
+
 2021-03-29  Katsumi Yamaoka  <yamaoka@jpl.org>
 
 	Delete useless history warning

--- a/w3m-proc.el
+++ b/w3m-proc.el
@@ -231,9 +231,10 @@ number of current working processes is less than `w3m-process-max'."
 	      (throw 'last nil)
 	    (w3m-process-start-process obj)))))))
 
-(defun w3m-process-stop (buffer)
-  "Remove handlers related to the buffer BUFFER, and stop processes
-which have no handler."
+(defun w3m-process-stop (buffer &optional kill)
+  "Remove handlers related to the buffer BUFFER, and stop
+processes which have no handler. When optional arg KILL is
+non-nil, kill the buffer BUFFER."
   (interactive (list (current-buffer)))
   (w3m-cancel-refresh-timer buffer)
   (setq w3m-process-queue
@@ -286,14 +287,16 @@ which have no handler."
 	(goto-char (point-min))
 	(if (re-search-forward "\n*\\( *\\)Reading [^\n]+\\(\\.\\.\\.\\)"
 			       nil t)
-	    (let ((inhibit-read-only t))
-	      (delete-region (match-beginning 2) (point-max))
-	      (insert "\n\n" (match-string 1) "Operation aborted by user.")
-	      (delete-region 1 (min 3 (match-beginning 1)))
-	      (set-buffer-modified-p nil)
-	      (setq w3m-current-url nil
-		    w3m-current-title nil))
-	  (goto-char pt)))))
+            (if kill
+              (kill-buffer buffer)
+             (let ((inhibit-read-only t))
+               (delete-region (match-beginning 2) (point-max))
+               (insert "\n\n" (match-string 1) "Operation aborted by user.")
+               (delete-region 1 (min 3 (match-beginning 1)))
+               (set-buffer-modified-p nil)
+               (setq w3m-current-url nil
+                     w3m-current-title nil)))
+          (goto-char pt)))))
   (w3m-force-window-update-later buffer))
 
 (defun w3m-process-shutdown ()

--- a/w3m.el
+++ b/w3m.el
@@ -8222,15 +8222,16 @@ it may be useless if the command is invoked for visiting a local file
 or a mail buffer.  This command will delete BUFFER if it is empty or
 there is only a progress message.  It also deletes windows and frames
 related to BUFFER."
-  (with-current-buffer buffer
-    (unless (or w3m-current-process
-		w3m-current-url
-		(not (or (zerop (buffer-size))
-			 (and (get-text-property (point-min)
-						 'w3m-progress-message)
-			      (get-text-property (1- (point-max))
-						 'w3m-progress-message)))))
-      (w3m-delete-buffer t))))
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (unless (or w3m-current-process
+                  w3m-current-url
+                  (not (or (zerop (buffer-size))
+                           (and (get-text-property (point-min)
+                                                   'w3m-progress-message)
+                                (get-text-property (1- (point-max))
+                                                   'w3m-progress-message)))))
+        (w3m-delete-buffer t)))))
 
 (defun w3m-pack-buffer-numbers ()
   "Renumber suffixes of names of emacs-w3m buffers.

--- a/w3m.el
+++ b/w3m.el
@@ -4034,7 +4034,7 @@ even in new sessions if the `w3m-toggle-inline-images-permanently'
 variable is non-nil (default=t)."
   (interactive "P")
   (unless (display-images-p)
-    (error "Can't display images in this environment"))
+    (user-error "Can't display images in this environment"))
   (let ((status (cond ((eq force 'turnoff) t)
 		      (force nil)
 		      (t w3m-display-inline-images)))
@@ -6552,7 +6552,7 @@ while running BODY."
 
 (defsubst w3m-image-page-displayed-p ()
   (and w3m-current-url
-       (string-match "\\`image/" (w3m-content-type w3m-current-url))
+       (string-match "\\`image/" (or (w3m-content-type w3m-current-url) ""))
        (eq (get-text-property (point-min) 'w3m-image-status) 'on)))
 
 (defun w3m-create-image-page (url type _charset page-buffer)
@@ -7069,7 +7069,7 @@ previous page."
 	 ((and (equal w3m-current-url "about://cookie/")
 	       (> (length (w3m-list-buffers t)) 1))
 	  (w3m-delete-buffer))
-	 ((string-match "^about://" w3m-current-url)
+	 ((string-match "^about://" (or w3m-current-url ""))
 	  (setq hist (w3m-history-backward 0))
 	  (w3m-goto-url (caar hist) nil nil
 			(w3m-history-plist-get :post-data)
@@ -9646,6 +9646,7 @@ helpful message is presented and the operation is aborted."
 					    redisplay name reuse-history action
 					    orig history-position)
   (with-current-buffer w3m-current-buffer
+    (when w3m-current-url
     (setq w3m-current-process nil)
     (if (not action)
 	(w3m-history-push w3m-current-url
@@ -9744,7 +9745,7 @@ helpful message is presented and the operation is aborted."
     (when (or reload redisplay)
       (w3m-history-restore-position))
     (unless redisplay (w3m-set-buffer-unseen))
-    (w3m-refresh-at-time)))
+    (w3m-refresh-at-time))))
 
 (defun w3m--goto-url--valid-url (url reload charset post-data referer handler
 				     element background save-pos)
@@ -9756,7 +9757,7 @@ helpful message is presented and the operation is aborted."
     (w3m-popup-buffer (current-buffer)))
   (w3m-cancel-refresh-timer (current-buffer))
   (w3m--buffer-busy-error)
-  (w3m-process-stop (current-buffer))	; Stop all processes retrieving images.
+  (w3m-process-stop (current-buffer) 'kill)	; Stop all processes retrieving images.
   (w3m-idle-images-show-unqueue (current-buffer))
   ;; Store the current position in the history structure if SAVE-POS
   ;; is set or `w3m-goto-url' is called interactively.


### PR DESCRIPTION
+ Several instances were found of string operations being performed on
  w3m-current-url without checking if the variable was a string.

+ When an external program calls emacs/emacs-w3m to open a URI that is
  an image, and emacs-w3m is configured to view that filetype
  externally, it still creates a new emac-w3m buffer.

  + This patch deletes the created buffer; however, wouldn't it be
    better never to create it in the first place?

  + That might not be possible because the way asynchronous processes
    need to be associated with a buffer, but even so the current
    situation needlessly makesthe new buffer a copy of the most recent
    emacs-w3m buffer.