### PR TITLE
tweaks to handling url query parts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2021-05-04  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-util.el (w3m-queries-log-file): Improve defcustom.
+	(w3m--url-get-queries): New function.
+	(w3m--url-strip-unwanted-queries): Improve name of function. was
+	w3m--url-strip-queries.
+
+	* w3m.el (w3m--retrieve-1--handler-function)
+	(w3m--goto-url--valid-url): Apply new function name.
+
+
 2021-04-13  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m.el (w3m-external-view): When a w3m buffer is created for the sole

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-05-06  Boruch Baum  <boruch_baum@gmx.com>
+
+	* w3m-util.el (w3m-queries-log-file): Use expand-file-name for variable
+	default definition.
+
 2021-05-04  Boruch Baum  <boruch_baum@gmx.com>
 
 	* w3m-util.el (w3m-queries-log-file): Improve defcustom.

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1151,6 +1151,22 @@ Otherwise return nil."
       (match-string 1 url)
     url))
 
+(defun w3m--url-get-queries (url)
+  "Returns an ALIST of queries in URL.
+ie. For anything after the first '?', for each segment until the
+next '&' or end-of-string, a CONS whose CAR is what is to the
+left of '=' and whose CDR is to the right of it."
+  (let ((parameters (when (string-match "[^?]+\\?\\(.*\\)$" url)
+                      (match-string 1 url)))
+        split query result)
+    (when parameters
+      (setq split (split-string parameters "&" 'omit-nulls))
+      (while (setq query (pop split))
+        (if (string-match "\\([^=]+\\)=\\(.*\\)$" query)
+          (push (cons (match-string 1 query) (match-string 2 query)) result)
+         (push (cons query "") result))))
+    result))
+
 (defcustom w3m-strip-queries t
   "Remove unwanted queries from URLs.
 Details are set by `w3m-strip-queries-alist'."
@@ -1174,12 +1190,13 @@ referers embed."
   :group 'w3m
   :type 'boolean)
 
-(defcustom w3m-queries-log-file "~/emacs-w3m-queries_log.txt"
+(defcustom w3m-queries-log-file (concat w3m-profile-directory
+                                        "emacs-w3m-queries_log.txt")
   "File in which to log URL queries."
   :group 'w3m
-  :type 'boolean)
+  :type 'file)
 
-(defun w3m--url-strip-queries (url)
+(defun w3m--url-strip-unwanted-queries (url)
   "Strip unwanted queries from a url.
 This is meant to remove unwanted trackers or other data that
 websites or referers embed. See `w3m-strip-queries-alist'."

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -1190,8 +1190,9 @@ referers embed."
   :group 'w3m
   :type 'boolean)
 
-(defcustom w3m-queries-log-file (concat w3m-profile-directory
-                                        "emacs-w3m-queries_log.txt")
+(defcustom w3m-queries-log-file (expand-file-name
+				  "emacs-w3m-queries_log.txt"
+				  w3m-profile-directory)
   "File in which to log URL queries."
   :group 'w3m
   :type 'file)

--- a/w3m.el
+++ b/w3m.el
@@ -5560,7 +5560,7 @@ It will put the retrieved contents into the current buffer.  See
 (defun w3m--retrieve-1--handler-function (url post-data referer no-cache
 					      counter handler temp-file attr)
   (when (nth 6 attr)
-    (setf (nth 6 attr) (w3m--url-strip-queries (nth 6 attr))))
+    (setf (nth 6 attr) (w3m--url-strip-unwanted-queries (nth 6 attr))))
   (and temp-file
        (file-exists-p temp-file)
        (delete-file temp-file))
@@ -9759,7 +9759,7 @@ helpful message is presented and the operation is aborted."
 (defun w3m--goto-url--valid-url (url reload charset post-data referer handler
 				     element background save-pos)
   "Main function called by `w3m-goto-url' for handling generic URLS."
-  (setq url (w3m--url-strip-queries url))
+  (setq url (w3m--url-strip-unwanted-queries url))
   (w3m-buffer-setup)			; Setup buffer.
   (w3m-arrived-setup)			; Setup arrived database.
   (unless background


### PR DESCRIPTION
+ Reference commits: c91e761f3, cc4ae1cbb

+ defcustom w3m-queries-log-file had been defined as boolean; define
  it as type 'file, and improve its default location.

+ New utility function w3m--url-get-queries. I've started using it in
  my w3m-download.el, but it can be useful for the query-tracker feature
  and any other feature that looks at the query section of a url.

+ w3m--url-strip-queries: What an awful and misleading name I gave
  that function back when. Much better name is
  w3m--url-strip-unwanted-queries