### PR TITLE
Address error in toggling vertical/horizontal popup window splits.

### DIFF
--- a/w3m.el
+++ b/w3m.el
@@ -11243,7 +11243,7 @@ beside the main window."
     (unless (eq nomsg 'update)
       (setq w3m-select-buffer-window selected-window))
     (let ((w (or (get-buffer-window buffer-name)
-		 (split-window selected-window
+		 (split-window (selected-window)
 			       (w3m-select-buffer-window-size)
 			       w3m-select-buffer-horizontal-window))))
       (set-window-buffer w (current-buffer))

--- a/w3m.el
+++ b/w3m.el
@@ -11240,14 +11240,14 @@ beside the main window."
 	    (w3m-popup-buffer buffer)
 	  (w3m-goto-url (or w3m-home-page "about:")))))
     (set-buffer (w3m-get-buffer-create buffer-name))
-    (unless (eq nomsg 'update)
-      (setq w3m-select-buffer-window selected-window))
     (let ((w (or (get-buffer-window buffer-name)
 		 (split-window (selected-window)
 			       (w3m-select-buffer-window-size)
 			       w3m-select-buffer-horizontal-window))))
       (set-window-buffer w (current-buffer))
-      (select-window w))))
+      (select-window w)
+      (unless (eq nomsg 'update)
+	(setq w3m-select-buffer-window (selected-window))))))
 
 (defun w3m-select-buffer (&optional toggle nomsg)
   "Pop-up an emacs-w3m buffers selection window.

--- a/w3m.el
+++ b/w3m.el
@@ -11240,14 +11240,14 @@ beside the main window."
 	    (w3m-popup-buffer buffer)
 	  (w3m-goto-url (or w3m-home-page "about:")))))
     (set-buffer (w3m-get-buffer-create buffer-name))
+    (unless (eq nomsg 'update)
+      (setq w3m-select-buffer-window (selected-window)))
     (let ((w (or (get-buffer-window buffer-name)
 		 (split-window (selected-window)
 			       (w3m-select-buffer-window-size)
 			       w3m-select-buffer-horizontal-window))))
       (set-window-buffer w (current-buffer))
-      (select-window w)
-      (unless (eq nomsg 'update)
-	(setq w3m-select-buffer-window (selected-window))))))
+      (select-window w))))
 
 (defun w3m-select-buffer (&optional toggle nomsg)
   "Pop-up an emacs-w3m buffers selection window.


### PR DESCRIPTION
By the time split-window is called, the locally let selected-window variable is no longer a valid window. Thus, we *actually* need to call the selected-window function here.