### PR TITLE
force-wide-display

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-07-28  Boruch Baum  <boruch_baum@gmx.com>
+
+	*  (w3m--ignore-fill-column, w3m-force-wide-list): New variables.
+	(w3m-create-page, w3m-display-width): Use them.
+	(w3m-display-width): Logic bug fixes.
+	(w3m-about-db-history): Reverse layout so time/date are on left side.
+	Manually force variable w3m-fill-column to -1.
+
 2021-06-15  Victor J. Orlikowski  <vjo@duke.edu>
 
 	Bugfix: make w3m-select-buffer-toggle-style work properly (PR#95)


### PR DESCRIPTION
+ It is desirable for normal web pages to have a limited text width
  because beyond a certain width, it is difficult to return to the
  proper next line. However, the content of some pages does make sense
  to always take advantage of the full width of a window. This commit
  enables that distinction to be made, by url regex, and uses that
  feature for the 'flat' history display pages, as created by M-x
  w3m-db-history.

+ The layout of w3m-db-history pages is reversed to put the short and
  constant width field (date/time) on the left.

+ Function w3m-about-db-history has some unusual code that directly
  calls function w3m-display-width instead of via w3m-create-page, so
  it was necessary there to manually set variable w3m-fill-column to
  -1. I tried several other techniques, but for any other to work
  involved even more ugly code.

+ If hl-line mode is available, in is enabled for pages that are
  forced wide.

+ Logic bugs in function w3m-display-width were 'fixed'. They weren't
  breaking things, but they have been marked for years as nonsense
  lines with noone taking the courage to remove them.

  + There were two of these bugs: "FIXME: that the session-select
    window is selected at this time would probably be due to a bug."
    and "BUG: The final 'or' statement makes no sense, because
    w3m-fill-column is an integer, and if for some reason it had been
    set nil, then the '<' test above would have crashed the function"