### PR TITLE
support package-lint, using file .dir-locals.el

### DIFF
--- a/shimbun/.dir-locals.el
+++ b/shimbun/.dir-locals.el
@@ -1,4 +1,4 @@
-((nil . ((package-lint-main-file . "w3m.el")
+((nil . ((package-lint-main-file . "shimbun.el")
 	 (indent-tabs-mode . t))))
 ;; Local Variables:
 ;; no-byte-compile: t

--- a/w3m-util.el
+++ b/w3m-util.el
@@ -836,7 +836,7 @@ has to initially exist between the end position of the closing-tag and
 the previous tag as follows:
 
 <!-- foo <bar ...<baz ...>...> -->
-                              ^^^
+			      ^^^
 If INCLUDE-WHITESPACE is non-nil, include leading and trailing
 whitespace.  Return the end-point and set the match-data #0, #1, #2,
 and #3 as follows (\"___\" shows whitespace):


### PR DESCRIPTION
+ package-lint is a common syntax checker for elisp files to encourage
  compliance with Emacs style guidelines.

+ When a package (project) is split across more than one file,
  package-lint gets confused because it uses the elisp file name as
  the basis for the package namespace.

+ File-local variable package-lint-main-file is used to avoid the
  confusion.

+ We define the variable once in .dir-locals.el in order to avoid
  needing to create an stanza for file-local variables in each of the
  160+ files of the project.

+ The variable needs to be set separately for the shimbun directory
  because of the separate namespace used there.

+ Commit c7905881 is a minor, questionable, and unrelated issue that
  arose when automating enforcement of tabs instead of spaces. See
  there and possibly drop the commit if undesirable.